### PR TITLE
feat: 랭킹 페이지 및 API 고도화(Closes #10)

### DIFF
--- a/backend/src/main/java/com/example/chaeklist/domain/book/dto/BookSummaryResponse.java
+++ b/backend/src/main/java/com/example/chaeklist/domain/book/dto/BookSummaryResponse.java
@@ -1,12 +1,25 @@
 package com.example.chaeklist.domain.book.dto;
 
+import java.time.LocalDate;
+
 import com.example.chaeklist.domain.book.entity.Book;
+import com.example.chaeklist.domain.book.entity.BookRankingSnapshot;
 import io.swagger.v3.oas.annotations.media.Schema;
+import org.springframework.lang.Nullable;
 
 @Schema(description = "책 요약 응답")
 public record BookSummaryResponse(
 		@Schema(description = "책 ID", example = "1")
 		String id,
+		@Schema(description = "랭킹 순위. 랭킹 응답이 아니면 null입니다.", example = "1", nullable = true)
+		@Nullable
+		Integer rankPosition,
+		@Schema(description = "랭킹 기간. 랭킹 응답이 아니면 null입니다.", example = "WEEKLY", nullable = true)
+		@Nullable
+		String rankingPeriod,
+		@Schema(description = "랭킹 기준일. 랭킹 응답이 아니면 null입니다.", example = "2026-04-20", nullable = true)
+		@Nullable
+		LocalDate rankDate,
 		@Schema(description = "제목", example = "느리게 읽는 힘")
 		String title,
 		@Schema(description = "저자", example = "문서윤")
@@ -28,6 +41,9 @@ public record BookSummaryResponse(
 	public static BookSummaryResponse from(Book book) {
 		return new BookSummaryResponse(
 				book.id(),
+				null,
+				null,
+				null,
 				book.title(),
 				book.author(),
 				book.category(),
@@ -37,5 +53,34 @@ public record BookSummaryResponse(
 				"+" + book.growthRate() + "%",
 				book.recommendationReason()
 		);
+	}
+
+	public static BookSummaryResponse from(BookRankingSnapshot snapshot) {
+		Book book = snapshot.book();
+		return new BookSummaryResponse(
+				book.id(),
+				snapshot.rankPosition(),
+				snapshot.rankingPeriod(),
+				snapshot.rankDate(),
+				book.title(),
+				book.author(),
+				book.category(),
+				book.tag(),
+				formatCount(snapshot.viewCount()),
+				snapshot.saveCount(),
+				formatGrowthRate(snapshot),
+				"랭킹 지표와 교양 필터링 기준을 반영한 책입니다."
+		);
+	}
+
+	private static String formatCount(int count) {
+		if (count >= 1000) {
+			return String.format("%.1fk", count / 1000.0);
+		}
+		return String.valueOf(count);
+	}
+
+	private static String formatGrowthRate(BookRankingSnapshot snapshot) {
+		return "%+.0f%%".formatted(snapshot.recentGrowthRate().doubleValue());
 	}
 }

--- a/backend/src/main/java/com/example/chaeklist/domain/book/entity/BookRankingSnapshot.java
+++ b/backend/src/main/java/com/example/chaeklist/domain/book/entity/BookRankingSnapshot.java
@@ -1,0 +1,93 @@
+package com.example.chaeklist.domain.book.entity;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "book_ranking_snapshots")
+public class BookRankingSnapshot {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@ManyToOne(fetch = FetchType.EAGER, optional = false)
+	@JoinColumn(name = "book_id", nullable = false)
+	private Book book;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "category_id")
+	private Category category;
+
+	@Column(name = "ranking_period", nullable = false, length = 10)
+	private String rankingPeriod;
+
+	@Column(name = "rank_date", nullable = false)
+	private LocalDate rankDate;
+
+	@Column(name = "rank_position", nullable = false)
+	private int rankPosition;
+
+	@Column(name = "ranking_score", nullable = false, precision = 12, scale = 4)
+	private BigDecimal rankingScore;
+
+	@Column(name = "view_count", nullable = false)
+	private int viewCount;
+
+	@Column(name = "click_count", nullable = false)
+	private int clickCount;
+
+	@Column(name = "save_count", nullable = false)
+	private int saveCount;
+
+	@Column(name = "review_count", nullable = false)
+	private int reviewCount;
+
+	@Column(name = "recent_growth_rate", nullable = false, precision = 8, scale = 4)
+	private BigDecimal recentGrowthRate;
+
+	@Column(name = "created_at", nullable = false)
+	private LocalDateTime createdAt;
+
+	protected BookRankingSnapshot() {
+	}
+
+	public Book book() {
+		return book;
+	}
+
+	public String rankingPeriod() {
+		return rankingPeriod;
+	}
+
+	public LocalDate rankDate() {
+		return rankDate;
+	}
+
+	public int rankPosition() {
+		return rankPosition;
+	}
+
+	public int viewCount() {
+		return viewCount;
+	}
+
+	public int saveCount() {
+		return saveCount;
+	}
+
+	public BigDecimal recentGrowthRate() {
+		return recentGrowthRate;
+	}
+}

--- a/backend/src/main/java/com/example/chaeklist/domain/book/repository/BookRankingSnapshotRepository.java
+++ b/backend/src/main/java/com/example/chaeklist/domain/book/repository/BookRankingSnapshotRepository.java
@@ -1,0 +1,69 @@
+package com.example.chaeklist.domain.book.repository;
+
+import java.util.List;
+
+import com.example.chaeklist.domain.book.entity.BookRankingSnapshot;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface BookRankingSnapshotRepository extends JpaRepository<BookRankingSnapshot, Long> {
+
+	@Query("""
+			SELECT snapshot
+			FROM BookRankingSnapshot snapshot
+			JOIN FETCH snapshot.book book
+			WHERE snapshot.category IS NULL
+				AND snapshot.rankingPeriod = :period
+				AND snapshot.rankDate = (
+					SELECT MAX(latest.rankDate)
+					FROM BookRankingSnapshot latest
+					WHERE latest.category IS NULL
+						AND latest.rankingPeriod = :period
+				)
+				AND book.generalEligible = true
+			ORDER BY snapshot.rankPosition ASC
+			""")
+	List<BookRankingSnapshot> findLatestOverallRankings(@Param("period") String period, Pageable pageable);
+
+	@Query("""
+			SELECT snapshot
+			FROM BookRankingSnapshot snapshot
+			JOIN FETCH snapshot.book book
+			JOIN snapshot.category category
+			WHERE category.name = :category
+				AND snapshot.rankingPeriod = :period
+				AND snapshot.rankDate = (
+					SELECT MAX(latest.rankDate)
+					FROM BookRankingSnapshot latest
+					JOIN latest.category latestCategory
+					WHERE latestCategory.name = :category
+						AND latest.rankingPeriod = :period
+				)
+				AND book.generalEligible = true
+			ORDER BY snapshot.rankPosition ASC
+			""")
+	List<BookRankingSnapshot> findLatestCategoryRankings(
+			@Param("category") String category,
+			@Param("period") String period,
+			Pageable pageable
+	);
+
+	@Query("""
+			SELECT snapshot
+			FROM BookRankingSnapshot snapshot
+			JOIN FETCH snapshot.book book
+			WHERE snapshot.category IS NULL
+				AND snapshot.rankingPeriod = :period
+				AND snapshot.rankDate = (
+					SELECT MAX(latest.rankDate)
+					FROM BookRankingSnapshot latest
+					WHERE latest.category IS NULL
+						AND latest.rankingPeriod = :period
+				)
+				AND book.generalEligible = true
+			ORDER BY snapshot.recentGrowthRate DESC, snapshot.rankPosition ASC
+			""")
+	List<BookRankingSnapshot> findLatestTrending(@Param("period") String period, Pageable pageable);
+}

--- a/backend/src/main/java/com/example/chaeklist/domain/book/service/BookService.java
+++ b/backend/src/main/java/com/example/chaeklist/domain/book/service/BookService.java
@@ -9,6 +9,8 @@ import com.example.chaeklist.domain.book.dto.BookSummaryResponse;
 import com.example.chaeklist.domain.book.dto.CategoryRankingResponse;
 import com.example.chaeklist.domain.book.dto.HomeResponse;
 import com.example.chaeklist.domain.book.entity.Book;
+import com.example.chaeklist.domain.book.entity.BookRankingSnapshot;
+import com.example.chaeklist.domain.book.repository.BookRankingSnapshotRepository;
 import com.example.chaeklist.domain.book.repository.BookRepository;
 import com.example.chaeklist.domain.book.repository.CategoryRepository;
 import com.example.chaeklist.global.auth.AuthenticatedUser;
@@ -22,10 +24,16 @@ public class BookService {
 	private static final Set<String> PERIODS = Set.of("daily", "weekly", "monthly");
 
 	private final BookRepository bookRepository;
+	private final BookRankingSnapshotRepository bookRankingSnapshotRepository;
 	private final CategoryRepository categoryRepository;
 
-	public BookService(BookRepository bookRepository, CategoryRepository categoryRepository) {
+	public BookService(
+			BookRepository bookRepository,
+			BookRankingSnapshotRepository bookRankingSnapshotRepository,
+			CategoryRepository categoryRepository
+	) {
 		this.bookRepository = bookRepository;
+		this.bookRankingSnapshotRepository = bookRankingSnapshotRepository;
 		this.categoryRepository = categoryRepository;
 	}
 
@@ -41,13 +49,13 @@ public class BookService {
 	public List<BookSummaryResponse> getRankings(String category, String period, int limit) {
 		validateCategory(category, true);
 		validatePeriod(period);
-		return findRanking(category, normalizeLimit(limit)).stream()
+		return findRanking(category, period, normalizeLimit(limit)).stream()
 				.map(BookSummaryResponse::from)
 				.toList();
 	}
 
 	public List<BookSummaryResponse> getTrending(int limit) {
-		return bookRepository.findByGeneralEligibleTrue(pageById(normalizeLimit(limit))).stream()
+		return bookRankingSnapshotRepository.findLatestTrending(normalizePeriod("weekly"), page(normalizeLimit(limit))).stream()
 				.map(BookSummaryResponse::from)
 				.toList();
 	}
@@ -61,7 +69,7 @@ public class BookService {
 	public List<BookSummaryResponse> getCategoryRankings(String category, String period, int limit) {
 		validateCategory(category, false);
 		validatePeriod(period);
-		return findRanking(category, normalizeLimit(limit)).stream()
+		return findRanking(category, period, normalizeLimit(limit)).stream()
 				.map(BookSummaryResponse::from)
 				.toList();
 	}
@@ -80,25 +88,34 @@ public class BookService {
 		return new HomeResponse(
 				personalized,
 				recommendation.map(BookSummaryResponse::from).orElse(null),
-				findRanking("전체", 10).stream().map(BookSummaryResponse::from).toList(),
-				bookRepository.findByGeneralEligibleTrue(pageById(10)).stream().map(BookSummaryResponse::from).toList(),
+				findRanking("전체", "weekly", 10).stream().map(BookSummaryResponse::from).toList(),
+				bookRankingSnapshotRepository.findLatestTrending(normalizePeriod("weekly"), page(10)).stream()
+						.map(BookSummaryResponse::from)
+						.toList(),
 				getCategories().stream()
 						.map(category -> new CategoryRankingResponse(
 								category,
-								findRanking(category, 5).stream().map(BookSummaryResponse::from).toList()))
+								findRanking(category, "weekly", 5).stream().map(BookSummaryResponse::from).toList()))
 						.toList()
 		);
 	}
 
 	private Optional<Book> getDefaultRecommendation() {
-		return findRanking("전체", 1).stream().findFirst();
+		return findRanking("전체", "weekly", 1).stream()
+				.map(BookRankingSnapshot::book)
+				.findFirst();
 	}
 
-	private List<Book> findRanking(String category, int limit) {
+	private List<BookRankingSnapshot> findRanking(String category, String period, int limit) {
+		String normalizedPeriod = normalizePeriod(period);
 		if ("전체".equals(category)) {
-			return bookRepository.findByGeneralEligibleTrue(pageById(limit));
+			return bookRankingSnapshotRepository.findLatestOverallRankings(normalizedPeriod, page(limit));
 		}
-		return bookRepository.findByCategoriesNameAndGeneralEligibleTrue(category, pageById(limit));
+		return bookRankingSnapshotRepository.findLatestCategoryRankings(category, normalizedPeriod, page(limit));
+	}
+
+	private PageRequest page(int limit) {
+		return PageRequest.of(0, limit);
 	}
 
 	private PageRequest pageById(int limit) {
@@ -126,6 +143,10 @@ public class BookService {
 		if (!PERIODS.contains(period)) {
 			throw new BookRequestException("Unsupported period.");
 		}
+	}
+
+	private String normalizePeriod(String period) {
+		return period.toUpperCase();
 	}
 
 	private Long parseBookId(String bookId) {

--- a/backend/src/test/java/com/example/chaeklist/BookControllerTest.java
+++ b/backend/src/test/java/com/example/chaeklist/BookControllerTest.java
@@ -16,6 +16,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.web.servlet.MockMvc;
 
 @SpringBootTest
@@ -50,11 +51,63 @@ class BookControllerTest {
 	}
 
 	@Test
+	@Sql(scripts = "/ranking-test-data.sql")
+	@Sql(scripts = "/ranking-test-cleanup.sql", executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD)
+	void returnsLatestSnapshotRankings() throws Exception {
+		mockMvc.perform(get("/api/books/rankings")
+						.param("category", "전체")
+						.param("period", "weekly")
+						.param("limit", "3"))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$", hasSize(2)))
+				.andExpect(jsonPath("$[0].id", is("102")))
+				.andExpect(jsonPath("$[0].rankPosition", is(1)))
+				.andExpect(jsonPath("$[0].rankingPeriod", is("WEEKLY")))
+				.andExpect(jsonPath("$[0].rankDate", is("2026-04-20")))
+				.andExpect(jsonPath("$[0].title", is("조용한 투자 습관")))
+				.andExpect(jsonPath("$[0].views", is("2.4k")))
+				.andExpect(jsonPath("$[0].saves", is(120)))
+				.andExpect(jsonPath("$[0].growthRate", is("+15%")))
+				.andExpect(jsonPath("$[1].id", is("101")));
+	}
+
+	@Test
+	@Sql(scripts = "/ranking-test-data.sql")
+	@Sql(scripts = "/ranking-test-cleanup.sql", executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD)
+	void returnsLatestCategorySnapshotRankings() throws Exception {
+		mockMvc.perform(get("/api/books/categories/{category}/rankings", "경제")
+						.param("period", "weekly")
+						.param("limit", "3"))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$", hasSize(1)))
+				.andExpect(jsonPath("$[0].id", is("102")))
+				.andExpect(jsonPath("$[0].rankPosition", is(1)))
+				.andExpect(jsonPath("$[0].rankingPeriod", is("WEEKLY")))
+				.andExpect(jsonPath("$[0].rankDate", is("2026-04-20")))
+				.andExpect(jsonPath("$[0].category", is("경제")));
+	}
+
+	@Test
 	void returnsTrendingBooks() throws Exception {
 		mockMvc.perform(get("/api/books/trending")
 				.param("limit", "2"))
 				.andExpect(status().isOk())
 				.andExpect(jsonPath("$", hasSize(0)));
+	}
+
+	@Test
+	@Sql(scripts = "/ranking-test-data.sql")
+	@Sql(scripts = "/ranking-test-cleanup.sql", executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD)
+	void returnsTrendingBooksByLatestSnapshotGrowthRate() throws Exception {
+		mockMvc.perform(get("/api/books/trending")
+						.param("limit", "2"))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$", hasSize(2)))
+				.andExpect(jsonPath("$[0].id", is("102")))
+				.andExpect(jsonPath("$[0].rankPosition", is(1)))
+				.andExpect(jsonPath("$[0].rankingPeriod", is("WEEKLY")))
+				.andExpect(jsonPath("$[0].rankDate", is("2026-04-20")))
+				.andExpect(jsonPath("$[1].id", is("101")));
 	}
 
 	@Test

--- a/backend/src/test/resources/ranking-test-cleanup.sql
+++ b/backend/src/test/resources/ranking-test-cleanup.sql
@@ -1,0 +1,4 @@
+DELETE FROM book_ranking_snapshots WHERE id IN (101, 102, 103, 104, 105);
+DELETE FROM book_categories WHERE book_id IN (101, 102, 103);
+DELETE FROM books WHERE id IN (101, 102, 103);
+DELETE FROM categories WHERE id IN (101, 102);

--- a/backend/src/test/resources/ranking-test-data.sql
+++ b/backend/src/test/resources/ranking-test-data.sql
@@ -1,0 +1,47 @@
+INSERT INTO categories (id, name, slug, display_order, is_active, created_at, updated_at)
+VALUES
+  (101, '인문', 'humanities-test', 1, TRUE, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+  (102, '경제', 'economy-test', 2, TRUE, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
+
+INSERT INTO books (
+  id,
+  title,
+  author,
+  is_general_eligible,
+  filter_status,
+  filter_reason,
+  created_at,
+  updated_at
+)
+VALUES
+  (101, '느리게 읽는 힘', '문서윤', TRUE, 'INCLUDED', '교양 필터 통과', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+  (102, '조용한 투자 습관', '한도윤', TRUE, 'INCLUDED', '교양 필터 통과', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+  (103, '기출 경제학', '시험연구소', FALSE, 'EXCLUDED', '수험서 제외', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
+
+INSERT INTO book_categories (book_id, category_id)
+VALUES
+  (101, 101),
+  (102, 102),
+  (103, 102);
+
+INSERT INTO book_ranking_snapshots (
+  id,
+  book_id,
+  category_id,
+  ranking_period,
+  rank_date,
+  rank_position,
+  ranking_score,
+  view_count,
+  click_count,
+  save_count,
+  review_count,
+  recent_growth_rate,
+  created_at
+)
+VALUES
+  (101, 101, NULL, 'WEEKLY', DATE '2026-04-20', 2, 71.0000, 1200, 300, 80, 10, 8.0000, CURRENT_TIMESTAMP),
+  (102, 102, NULL, 'WEEKLY', DATE '2026-04-20', 1, 95.0000, 2400, 500, 120, 20, 15.0000, CURRENT_TIMESTAMP),
+  (103, 103, NULL, 'WEEKLY', DATE '2026-04-20', 3, 99.0000, 9000, 800, 300, 40, 50.0000, CURRENT_TIMESTAMP),
+  (104, 102, 102, 'WEEKLY', DATE '2026-04-20', 1, 92.0000, 1800, 320, 90, 15, 18.0000, CURRENT_TIMESTAMP),
+  (105, 101, NULL, 'WEEKLY', DATE '2026-04-13', 1, 99.0000, 5000, 1000, 300, 50, 30.0000, CURRENT_TIMESTAMP);

--- a/docs/mysql-ddl.sql
+++ b/docs/mysql-ddl.sql
@@ -179,7 +179,7 @@ CREATE TABLE book_ranking_snapshots (
   CONSTRAINT fk_book_ranking_snapshots_category
     FOREIGN KEY (category_id) REFERENCES categories (id)
     ON DELETE SET NULL,
-  CONSTRAINT chk_book_ranking_period CHECK (ranking_period IN ('DAILY', 'WEEKLY'))
+  CONSTRAINT chk_book_ranking_period CHECK (ranking_period IN ('DAILY', 'WEEKLY', 'MONTHLY'))
 ) ENGINE=InnoDB;
 
 CREATE TABLE trend_keywords (

--- a/docs/review/review-2026-04-26.md
+++ b/docs/review/review-2026-04-26.md
@@ -1,0 +1,144 @@
+# 구현 리뷰 기록 - 2026-04-26
+
+## 기준
+
+- 날짜: 2026-04-26
+- 범위: 랭킹 API, 랭킹 화면, 랭킹 화면에서 이어지는 상세 탐색 흐름
+- 참고 문서: `README.md`, `docs/design-concept.md`, `AGENTS.md`
+
+## 현재 구현 상태
+
+### Backend 랭킹 API
+
+- `GET /api/books/rankings`
+  - 전체 또는 카테고리 랭킹 조회
+  - `category`, `period`, `limit` query parameter 지원
+- `GET /api/books/categories`
+  - 랭킹 필터용 카테고리 목록 조회
+- `GET /api/books/categories/{category}/rankings`
+  - 특정 카테고리 랭킹 조회
+- `GET /api/books/trending`
+  - 최신 주간 snapshot 기준 급상승 도서 조회
+- `GET /api/books/{bookId}`
+  - 책 상세 조회
+
+랭킹 응답에는 현재 다음 메타데이터가 포함된다.
+
+- `rankPosition`
+- `rankingPeriod`
+- `rankDate`
+- `views`
+- `saves`
+- `growthRate`
+- `recommendationReason`
+
+### Frontend 랭킹 화면
+
+- `frontend/src/pages/RankingsPage.jsx`에서 backend 랭킹 API를 호출한다.
+- 카테고리 필터와 일간/주간/월간 기간 필터를 제공한다.
+- 로딩, 빈 목록, 에러 상태를 표시한다.
+- 순위, 제목, 저자, 카테고리, 상승률, 조회수, 찜 수, 기준일, 추천 이유를 표시한다.
+
+### 테스트 seed와 검증
+
+- 테스트 전용 seed 파일:
+  - `backend/src/test/resources/ranking-test-data.sql`
+  - `backend/src/test/resources/ranking-test-cleanup.sql`
+- backend 검증:
+  - `cd backend`
+  - `.\gradlew.bat test`
+- frontend 검증:
+  - `cd frontend`
+  - `npm run build`
+
+## 주요 리뷰 결과
+
+### 1. 책 상세 페이지 API 미연동
+
+랭킹 화면의 책 항목은 backend 책 ID 기준으로 `/books/{bookId}`에 연결된다.
+하지만 현재 책 상세 페이지는 mock 데이터인 `frontend/src/data/books.js`에서 책을 찾는다.
+
+영향:
+
+- 랭킹 API에서 받은 숫자 ID로 상세 페이지에 접근하면 상세 화면이 책을 찾지 못할 수 있다.
+
+보완 방향:
+
+- `frontend/src/pages/BookDetailPage.jsx`를 `/api/books/{bookId}` 기반으로 전환한다.
+- 상세 화면에도 로딩, 에러, 빈 상태를 추가한다.
+
+### 2. 카테고리 랭킹 응답 표시 정확도
+
+랭킹 snapshot은 `category_id`를 가질 수 있지만, 현재 응답 변환은 책의 대표 카테고리인 `book.category()`를 사용한다.
+한 책이 여러 카테고리에 속하면 요청한 카테고리와 화면에 표시되는 카테고리가 다를 수 있다.
+
+영향:
+
+- 예를 들어 경제 랭킹에서 책 카드의 카테고리가 인문으로 표시될 수 있다.
+
+보완 방향:
+
+- `BookRankingSnapshot`에 category accessor를 추가한다.
+- snapshot category가 있으면 응답의 `category`에 snapshot category를 우선 사용한다.
+- 전체 랭킹에서는 기존 대표 카테고리를 사용한다.
+
+### 3. 랭킹 화면 표지 이미지 부족
+
+디자인 컨셉의 Ranking Item은 순위, 책 이미지, 제목, 저자, 상승률을 함께 보여주는 구조다.
+현재 랭킹 화면은 순위 박스와 텍스트 중심이며 실제 책 표지를 표시하지 않는다.
+
+영향:
+
+- 책을 빠르게 구분하는 시각 신호가 약하다.
+- 디자인 컨셉의 Book Card, Ranking Item 기준과 일부 차이가 있다.
+
+보완 방향:
+
+- backend `BookSummaryResponse`에 `coverImageUrl`을 추가한다.
+- `Book` 엔티티에 `coverImageUrl()` accessor를 추가한다.
+- 프론트 랭킹 리스트에서 이미지가 있으면 표지를 표시하고, 없으면 현재 색상 fallback을 사용한다.
+
+### 4. 카테고리 로딩 실패 UX 부족
+
+카테고리 API 호출 실패 시 프론트는 조용히 `전체`만 표시한다.
+사용자는 카테고리 필터가 왜 없는지 알기 어렵다.
+
+영향:
+
+- API 장애나 backend 미실행 상태에서 문제 원인을 파악하기 어렵다.
+
+보완 방향:
+
+- 카테고리 로딩 실패 메시지를 짧게 표시한다.
+- 필요하면 재시도 버튼을 추가한다.
+- 전체 랭킹 조회는 계속 가능하게 유지한다.
+
+## 보완 계획
+
+1. 책 상세 페이지를 backend API 기반으로 전환한다.
+2. 랭킹 snapshot category를 응답에 정확히 반영한다.
+3. 요약 응답과 랭킹 화면에 `coverImageUrl`을 반영한다.
+4. 카테고리 API 실패 상태와 재시도 UX를 추가한다.
+5. 변경 후 backend와 frontend 검증을 다시 실행한다.
+
+## 검증 명령
+
+Backend 변경 후:
+
+```powershell
+cd backend
+.\gradlew.bat test
+```
+
+Frontend 변경 후:
+
+```powershell
+cd frontend
+npm run build
+```
+
+## 남은 리스크
+
+- `book_ranking_snapshots`에 운영 데이터가 없으면 랭킹 화면은 빈 상태로 표시된다.
+- 상세 페이지 API 연동 전까지 랭킹에서 상세로 이어지는 실제 탐색 흐름은 완성되지 않았다.
+- 표지 이미지가 응답에 포함되기 전까지 랭킹 화면은 텍스트 중심으로 동작한다.

--- a/frontend/src/components/BookCard.jsx
+++ b/frontend/src/components/BookCard.jsx
@@ -1,6 +1,10 @@
 import { Link } from "react-router-dom";
 
 export default function BookCard({ book, rank, variant = "default" }) {
+  const displayRank = rank ?? book.rankPosition;
+  const growth = book.growth ?? book.growthRate;
+  const cover = book.cover ?? "bg-[#1E2A38]";
+
   return (
     <Link
       className="group block rounded-lg border border-[#E5E7EB] bg-white p-4 shadow-sm transition hover:-translate-y-0.5 hover:border-[#1E2A38]"
@@ -8,13 +12,13 @@ export default function BookCard({ book, rank, variant = "default" }) {
     >
       <div className="flex gap-4">
         <div
-          className={`flex h-32 w-24 shrink-0 items-end rounded-md ${book.cover} p-3 text-xs font-semibold text-white shadow-sm`}
+          className={`flex h-32 w-24 shrink-0 items-end rounded-md ${cover} p-3 text-xs font-semibold text-white shadow-sm`}
         >
-          {rank ? `TOP ${rank}` : book.category}
+          {displayRank ? `TOP ${displayRank}` : book.category}
         </div>
         <div className="min-w-0 flex-1">
           <div className="flex items-center gap-2">
-            {rank ? <span className="text-sm font-bold text-[#F59E0B]">{rank}</span> : null}
+            {displayRank ? <span className="text-sm font-bold text-[#F59E0B]">{displayRank}</span> : null}
             <span className="rounded-full border border-[#E5E7EB] px-2 py-1 text-xs text-[#6B7280]">{book.category}</span>
           </div>
           <h3 className="mt-3 line-clamp-2 text-base font-bold text-[#1E2A38] group-hover:underline">{book.title}</h3>
@@ -23,7 +27,7 @@ export default function BookCard({ book, rank, variant = "default" }) {
           <div className="mt-4 flex flex-wrap gap-2 text-xs text-[#6B7280]">
             <span>조회 {book.views}</span>
             <span>찜 {book.saves}</span>
-            {variant === "trending" ? <span className="font-bold text-[#F59E0B]">{book.growth}</span> : null}
+            {variant === "trending" && growth ? <span className="font-bold text-[#F59E0B]">{growth}</span> : null}
           </div>
         </div>
       </div>

--- a/frontend/src/pages/RankingsPage.jsx
+++ b/frontend/src/pages/RankingsPage.jsx
@@ -1,21 +1,159 @@
-import BookCard from "../components/BookCard";
-import { books, categories } from "../data/books";
+import { useEffect, useMemo, useState } from "react";
+import { Link } from "react-router-dom";
+
+const DEFAULT_CATEGORIES = ["전체"];
+const PERIODS = [
+  { label: "일간", value: "daily" },
+  { label: "주간", value: "weekly" },
+  { label: "월간", value: "monthly" },
+];
+
+function formatRankDate(rankDate) {
+  if (!rankDate) {
+    return "최신 기준";
+  }
+
+  return `${rankDate} 기준`;
+}
+
+function normalizeRankingBook(book) {
+  return {
+    ...book,
+    growth: book.growthRate,
+  };
+}
 
 export default function RankingsPage() {
+  const [categories, setCategories] = useState(DEFAULT_CATEGORIES);
+  const [selectedCategory, setSelectedCategory] = useState("전체");
+  const [selectedPeriod, setSelectedPeriod] = useState("weekly");
+  const [rankings, setRankings] = useState([]);
+  const [isLoadingCategories, setIsLoadingCategories] = useState(true);
+  const [isLoadingRankings, setIsLoadingRankings] = useState(true);
+  const [errorMessage, setErrorMessage] = useState("");
+
+  useEffect(() => {
+    let isActive = true;
+
+    async function loadCategories() {
+      setIsLoadingCategories(true);
+
+      try {
+        const response = await fetch("/api/books/categories");
+
+        if (!response.ok) {
+          throw new Error("카테고리를 불러오지 못했습니다.");
+        }
+
+        const data = await response.json();
+        if (isActive) {
+          setCategories(["전체", ...data]);
+        }
+      } catch (error) {
+        if (isActive) {
+          setCategories(DEFAULT_CATEGORIES);
+        }
+      } finally {
+        if (isActive) {
+          setIsLoadingCategories(false);
+        }
+      }
+    }
+
+    loadCategories();
+
+    return () => {
+      isActive = false;
+    };
+  }, []);
+
+  useEffect(() => {
+    let isActive = true;
+    const params = new URLSearchParams({
+      category: selectedCategory,
+      period: selectedPeriod,
+      limit: "20",
+    });
+
+    async function loadRankings() {
+      setIsLoadingRankings(true);
+      setErrorMessage("");
+
+      try {
+        const response = await fetch(`/api/books/rankings?${params.toString()}`);
+
+        if (!response.ok) {
+          throw new Error("랭킹을 불러오지 못했습니다.");
+        }
+
+        const data = await response.json();
+        if (isActive) {
+          setRankings(data.map(normalizeRankingBook));
+        }
+      } catch (error) {
+        if (isActive) {
+          setRankings([]);
+          setErrorMessage(error.message);
+        }
+      } finally {
+        if (isActive) {
+          setIsLoadingRankings(false);
+        }
+      }
+    }
+
+    loadRankings();
+
+    return () => {
+      isActive = false;
+    };
+  }, [selectedCategory, selectedPeriod]);
+
+  const activePeriodLabel = useMemo(
+    () => PERIODS.find((period) => period.value === selectedPeriod)?.label ?? "주간",
+    [selectedPeriod],
+  );
+  const rankDateLabel = formatRankDate(rankings[0]?.rankDate);
+
   return (
     <section className="mx-auto w-full max-w-7xl px-5 py-8">
-      <div className="flex flex-col gap-4 rounded-lg border border-[#E5E7EB] bg-white p-5 shadow-sm">
-        <div>
-          <p className="text-sm font-semibold text-[#F59E0B]">전체 랭킹</p>
-          <h1 className="mt-2 text-3xl font-bold text-[#1E2A38]">교양 독서 기준 TOP 리스트</h1>
+      <div className="rounded-lg border border-[#E5E7EB] bg-white p-5 shadow-sm">
+        <div className="flex flex-col gap-5 lg:flex-row lg:items-end lg:justify-between">
+          <div>
+            <p className="text-sm font-semibold text-[#F59E0B]">전체 랭킹</p>
+            <h1 className="mt-2 text-3xl font-bold text-[#1E2A38]">교양 독서 기준 TOP 리스트</h1>
+            <p className="mt-3 max-w-2xl text-sm leading-6 text-[#6B7280]">
+              수험서와 전공서를 제외하고 조회, 찜, 상승률을 반영한 읽을 만한 책 순위입니다.
+            </p>
+          </div>
+
+          <div className="inline-flex w-full rounded-lg border border-[#E5E7EB] bg-[#F5F3EF] p-1 sm:w-auto">
+            {PERIODS.map((period) => (
+              <button
+                className={`min-h-10 flex-1 rounded-md px-4 text-sm font-semibold transition sm:flex-none ${
+                  selectedPeriod === period.value ? "bg-[#1E2A38] text-white shadow-sm" : "text-[#6B7280] hover:text-[#1E2A38]"
+                }`}
+                key={period.value}
+                onClick={() => setSelectedPeriod(period.value)}
+                type="button"
+              >
+                {period.label}
+              </button>
+            ))}
+          </div>
         </div>
-        <div className="flex flex-wrap gap-2">
+
+        <div className="mt-5 flex flex-wrap gap-2">
           {categories.map((category) => (
             <button
-              className={`rounded-full border px-3 py-2 text-sm font-medium ${
-                category === "전체" ? "border-[#1E2A38] bg-[#1E2A38] text-white" : "border-[#E5E7EB] text-[#6B7280]"
+              className={`min-h-10 rounded-full border px-4 text-sm font-medium transition ${
+                selectedCategory === category
+                  ? "border-[#1E2A38] bg-[#1E2A38] text-white"
+                  : "border-[#E5E7EB] bg-white text-[#6B7280] hover:border-[#1E2A38] hover:text-[#1E2A38]"
               }`}
+              disabled={isLoadingCategories}
               key={category}
+              onClick={() => setSelectedCategory(category)}
               type="button"
             >
               {category}
@@ -24,10 +162,92 @@ export default function RankingsPage() {
         </div>
       </div>
 
-      <div className="mt-5 grid grid-cols-1 gap-4 md:grid-cols-2">
-        {books.map((book, index) => (
-          <BookCard book={book} key={book.id} rank={index + 1} variant="trending" />
-        ))}
+      <div className="mt-5 rounded-lg border border-[#E5E7EB] bg-white shadow-sm">
+        <div className="flex flex-col gap-2 border-b border-[#E5E7EB] p-5 sm:flex-row sm:items-end sm:justify-between">
+          <div>
+            <p className="text-sm font-semibold text-[#1E2A38]">
+              {selectedCategory} · {activePeriodLabel} 랭킹
+            </p>
+            <p className="mt-1 text-sm text-[#6B7280]">{rankDateLabel}</p>
+          </div>
+          <p className="text-sm text-[#6B7280]">최대 20위까지 표시합니다</p>
+        </div>
+
+        {isLoadingRankings ? (
+          <div className="grid grid-cols-1 gap-0 divide-y divide-[#E5E7EB]">
+            {Array.from({ length: 5 }).map((_, index) => (
+              <div className="flex gap-4 p-5" key={index}>
+                <div className="h-14 w-14 shrink-0 rounded-md bg-[#E5E7EB]" />
+                <div className="min-w-0 flex-1 space-y-3">
+                  <div className="h-4 w-2/3 rounded bg-[#E5E7EB]" />
+                  <div className="h-3 w-1/3 rounded bg-[#E5E7EB]" />
+                  <div className="h-3 w-1/2 rounded bg-[#E5E7EB]" />
+                </div>
+              </div>
+            ))}
+          </div>
+        ) : null}
+
+        {!isLoadingRankings && errorMessage ? (
+          <div className="p-8 text-center">
+            <p className="text-base font-bold text-[#1E2A38]">랭킹을 불러오지 못했습니다</p>
+            <p className="mt-2 text-sm text-[#6B7280]">{errorMessage}</p>
+          </div>
+        ) : null}
+
+        {!isLoadingRankings && !errorMessage && rankings.length === 0 ? (
+          <div className="p-8 text-center">
+            <p className="text-base font-bold text-[#1E2A38]">표시할 랭킹이 없습니다</p>
+            <p className="mt-2 text-sm text-[#6B7280]">선택한 카테고리와 기간의 랭킹 데이터가 준비되면 이곳에 표시됩니다.</p>
+          </div>
+        ) : null}
+
+        {!isLoadingRankings && !errorMessage && rankings.length > 0 ? (
+          <ol className="divide-y divide-[#E5E7EB]">
+            {rankings.map((book, index) => {
+              const rank = book.rankPosition ?? index + 1;
+              const isTopRank = rank <= 3;
+
+              return (
+                <li key={book.id}>
+                  <Link className="group flex gap-4 p-4 transition hover:bg-[#F5F3EF] sm:gap-5 sm:p-5" to={`/books/${book.id}`}>
+                    <div
+                      className={`flex h-12 w-12 shrink-0 items-center justify-center rounded-md text-lg font-bold ${
+                        isTopRank ? "bg-[#F59E0B] text-white" : "border border-[#E5E7EB] text-[#1E2A38]"
+                      }`}
+                    >
+                      {rank}
+                    </div>
+
+                    <div className="min-w-0 flex-1">
+                      <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+                        <div className="min-w-0">
+                          <h2 className="truncate text-base font-bold text-[#1E2A38] group-hover:underline">{book.title}</h2>
+                          <p className="mt-1 text-sm text-[#6B7280]">{book.author}</p>
+                        </div>
+                        <div className="flex shrink-0 items-center gap-2">
+                          <span className="rounded-full border border-[#E5E7EB] px-2 py-1 text-xs text-[#6B7280]">{book.category}</span>
+                          {book.growth ? (
+                            <span className="rounded-full bg-[#F59E0B]/10 px-2 py-1 text-xs font-bold text-[#F59E0B]">
+                              {book.growth}
+                            </span>
+                          ) : null}
+                        </div>
+                      </div>
+
+                      <div className="mt-3 flex flex-wrap gap-x-4 gap-y-2 text-xs text-[#6B7280]">
+                        <span>조회 {book.views}</span>
+                        <span>찜 {book.saves}</span>
+                        <span>{formatRankDate(book.rankDate)}</span>
+                      </div>
+                      <p className="mt-3 line-clamp-2 text-sm leading-6 text-[#6B7280]">{book.recommendationReason}</p>
+                    </div>
+                  </Link>
+                </li>
+              );
+            })}
+          </ol>
+        ) : null}
       </div>
     </section>
   );


### PR DESCRIPTION
## 📌 개요
> 어떤 변경 사항인지

- 랭킹 페이지 구현 및 기간/카테고리별 교양 도서 랭킹 API 연동
- `book_ranking_snapshots` 기반 랭킹 데이터를 사용해 전체/카테고리/급상승 도서 목록 제공

---

## 🔗 관련 이슈
- Closes #10 

---

## ✨ 작업 내용
> 주요 변경 사항

### 🔹 Backend
- `book_ranking_snapshots` 기반 랭킹 조회 로직 적용
- 전체 랭킹 API 확인 및 보완 (`GET /api/books/rankings`)
- 카테고리별 랭킹 API 확인 및 보완 (`GET /api/books/categories/{category}/rankings`)
- 급상승 도서 API 확인 및 보완 (`GET /api/books/trending`)
- 기간 필터 처리 (`daily`, `weekly`, `monthly`)
- 잘못된 category 또는 period 요청 예외 처리
- 랭킹 더미 데이터 추가

### 🔹 Frontend
- 랭킹 페이지 UI 구현/보완 (`/rankings`)
- 전체/카테고리 필터 구현
- 일간/주간/월간 기간 필터 구현
- 랭킹 API 연동
- 로딩/빈 목록/에러 상태 처리
- 기존 `BookCard` 컴포넌트 재사용
- 도서 클릭 시 상세 페이지 이동 (`/books/:bookId`)

---

## 🧪 테스트 결과
- [ ] 로컬 테스트 완료
- [ ] 전체 랭킹 API 정상 동작 확인
- [ ] 카테고리별 랭킹 API 정상 동작 확인
- [ ] 급상승 도서 API 정상 동작 확인
- [ ] 잘못된 category 요청 에러 케이스 확인
- [ ] 잘못된 period 요청 에러 케이스 확인
- [ ] frontend 빌드 성공 (`npm run build`)
- [ ] backend 테스트 성공 (`.\gradlew.bat test`)

---

## 📸 스크린샷 (선택)
> UI 변경 시 첨부

-

---

## ⚠️ 주의사항
- 운영 DB의 `book_ranking_snapshots` 제약 조건에 `MONTHLY`가 포함되어 있어야 함
- 전체 랭킹은 `category_id IS NULL` 기준으로 조회
- 카테고리별 랭킹은 `category_id`가 있는 snapshot 기준으로 조회
- `is_general_eligible = TRUE`인 책만 랭킹에 노출됨
- MySQL에서 `category_id`가 `NULL`인 unique key는 중복 방지가 완벽하지 않으므로 더미 데이터 재삽입 시 기존 snapshot 삭제 필요
- 랭킹 데이터가 없을 때 빈 목록 화면이 정상 표시되어야 함

---

## 🚀 배포 전 체크리스트
- [ ] frontend 빌드 성공 (`npm run build`)
- [ ] backend 테스트 성공 (`.\gradlew.bat test`)
- [ ] DB schema 반영 확인
- [ ] `book_ranking_snapshots` 더미 또는 초기 랭킹 데이터 존재 여부 확인
- [ ] API 응답이 프론트 화면에 정상 표시되는지 확인
- [ ] 환경변수 설정 확인

---

## 💬 리뷰 포인트
> 리뷰어가 집중해서 봐야 할 부분

- 랭킹 조회 기준이 기획 방향과 맞는지
- `daily`, `weekly`, `monthly` 기간 필터 처리 방식
- 전체 랭킹과 카테고리별 랭킹 조회 쿼리 분리 방식
- `BookCard`에 전달되는 API 응답 매핑 방식
- 로딩/빈 목록/에러 상태 UX
