### PR TITLE
feat: 마이 페이지 취향 수정 기능 추가(Closes #18)

### DIFF
--- a/frontend/src/pages/MyPage.jsx
+++ b/frontend/src/pages/MyPage.jsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
 import BookCard from "../components/BookCard";
 import { useAuth } from "../App";
 
@@ -12,6 +13,20 @@ function formatDate(value) {
     month: "2-digit",
     year: "numeric",
   }).format(new Date(value));
+}
+
+function EmptyState({ message, actionLabel, to }) {
+  return (
+    <div className="rounded-lg border border-dashed border-[#E5E7EB] bg-[#F9FAFB] p-5 text-sm text-[#6B7280]">
+      <p>{message}</p>
+      <Link
+        className="mt-4 inline-flex rounded-md bg-[#1E2A38] px-4 py-2 text-sm font-semibold text-white transition hover:bg-[#27384a]"
+        to={to}
+      >
+        {actionLabel}
+      </Link>
+    </div>
+  );
 }
 
 export default function MyPage() {
@@ -129,71 +144,124 @@ export default function MyPage() {
                 <p className="text-sm font-semibold text-[#1E2A38]">관심 분야</p>
                 <h2 className="mt-2 text-2xl font-bold text-[#1E2A38]">추천에 반영되는 독서 취향</h2>
               </div>
-              <span className="rounded-full bg-[#4CAF50]/10 px-3 py-2 text-xs font-semibold text-[#4CAF50]">API 데이터</span>
+              <Link
+                className="inline-flex rounded-md border border-[#E5E7EB] px-3 py-2 text-sm font-semibold text-[#1E2A38] transition hover:border-[#1E2A38]"
+                to="/onboarding?section=interests"
+              >
+                관심 분야 수정
+              </Link>
             </div>
 
-            <div className="mt-5 grid grid-cols-1 gap-4 md:grid-cols-3">
-              {interestProfiles.map((interest) => (
-                <article className="rounded-lg border border-[#E5E7EB] p-4" key={interest.label}>
-                  <div className="flex items-center justify-between gap-3">
-                    <h3 className="font-bold text-[#1E2A38]">{interest.label}</h3>
-                    <span className="text-sm font-bold text-[#F59E0B]">{interest.score}%</span>
-                  </div>
-                  <div className="mt-3 h-2 rounded-full bg-[#F5F3EF]">
-                    <div className="h-2 rounded-full bg-[#4CAF50]" style={{ width: `${interest.score}%` }} />
-                  </div>
-                  <p className="mt-3 text-sm leading-6 text-[#6B7280]">{interest.description}</p>
-                </article>
-              ))}
-            </div>
+            {!isLoading && interestProfiles.length === 0 ? (
+              <div className="mt-5">
+                <EmptyState
+                  actionLabel="관심 분야 선택"
+                  message="관심 분야를 선택하면 추천 이유가 더 구체적으로 바뀝니다."
+                  to="/onboarding?section=interests"
+                />
+              </div>
+            ) : (
+              <div className="mt-5 grid grid-cols-1 gap-4 md:grid-cols-3">
+                {interestProfiles.map((interest) => (
+                  <article className="rounded-lg border border-[#E5E7EB] p-4" key={interest.label}>
+                    <div className="flex items-center justify-between gap-3">
+                      <h3 className="font-bold text-[#1E2A38]">{interest.label}</h3>
+                      <span className="text-sm font-bold text-[#F59E0B]">{interest.score}%</span>
+                    </div>
+                    <div className="mt-3 h-2 rounded-full bg-[#F5F3EF]">
+                      <div className="h-2 rounded-full bg-[#4CAF50]" style={{ width: `${interest.score}%` }} />
+                    </div>
+                    <p className="mt-3 text-sm leading-6 text-[#6B7280]">{interest.description}</p>
+                  </article>
+                ))}
+              </div>
+            )}
           </section>
 
           <section className="rounded-lg border border-[#E5E7EB] bg-white p-5 shadow-sm">
-            <div>
-              <p className="text-sm font-semibold text-[#1E2A38]">읽은 책</p>
-              <h2 className="mt-2 text-2xl font-bold text-[#1E2A38]">취향 분석에 사용된 책</h2>
+            <div className="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
+              <div>
+                <p className="text-sm font-semibold text-[#1E2A38]">읽은 책</p>
+                <h2 className="mt-2 text-2xl font-bold text-[#1E2A38]">취향 분석에 사용된 책</h2>
+              </div>
+              <Link
+                className="inline-flex rounded-md border border-[#E5E7EB] px-3 py-2 text-sm font-semibold text-[#1E2A38] transition hover:border-[#1E2A38]"
+                to="/onboarding?section=read-books"
+              >
+                읽은 책 수정
+              </Link>
             </div>
-            <div className="mt-5 grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">
-              {readBooks.map((book) => (
-                <BookCard book={book} key={book.id} />
-              ))}
-            </div>
+            {!isLoading && readBooks.length === 0 ? (
+              <div className="mt-5">
+                <EmptyState
+                  actionLabel="읽은 책 추가"
+                  message="읽은 책을 추가하면 취향 분석에 반영됩니다."
+                  to="/onboarding?section=read-books"
+                />
+              </div>
+            ) : (
+              <div className="mt-5 grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">
+                {readBooks.map((book) => (
+                  <BookCard book={book} key={book.id} />
+                ))}
+              </div>
+            )}
           </section>
 
           <section className="grid grid-cols-1 gap-6 xl:grid-cols-[1fr_360px]">
             <div className="rounded-lg border border-[#E5E7EB] bg-white p-5 shadow-sm">
               <p className="text-sm font-semibold text-[#1E2A38]">추천 히스토리</p>
               <h2 className="mt-2 text-2xl font-bold text-[#1E2A38]">왜 추천됐는지 남기는 기록</h2>
-              <ol className="mt-5 divide-y divide-[#E5E7EB]">
-                {recommendationHistory.map((history) => (
-                  <li className="py-4 first:pt-0 last:pb-0" key={history.id}>
-                    <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
-                      <div>
-                        <p className="font-bold text-[#1E2A38]">{history.title}</p>
-                        <p className="mt-1 text-sm leading-6 text-[#6B7280]">{history.reason}</p>
+              {!isLoading && recommendationHistory.length === 0 ? (
+                <div className="mt-5">
+                  <EmptyState
+                    actionLabel="랭킹 보기"
+                    message="추천 근거가 쌓이면 이곳에서 확인할 수 있습니다."
+                    to="/rankings"
+                  />
+                </div>
+              ) : (
+                <ol className="mt-5 divide-y divide-[#E5E7EB]">
+                  {recommendationHistory.map((history) => (
+                    <li className="py-4 first:pt-0 last:pb-0" key={history.id}>
+                      <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+                        <div>
+                          <p className="font-bold text-[#1E2A38]">{history.title}</p>
+                          <p className="mt-1 text-sm leading-6 text-[#6B7280]">{history.reason}</p>
+                        </div>
+                        <span className="shrink-0 rounded-full border border-[#E5E7EB] px-3 py-1 text-xs text-[#6B7280]">
+                          {formatDate(history.generatedAt)}
+                        </span>
                       </div>
-                      <span className="shrink-0 rounded-full border border-[#E5E7EB] px-3 py-1 text-xs text-[#6B7280]">
-                        {formatDate(history.generatedAt)}
-                      </span>
-                    </div>
-                    <p className="mt-2 text-xs font-semibold text-[#4CAF50]">{history.source}</p>
-                  </li>
-                ))}
-              </ol>
+                      <p className="mt-2 text-xs font-semibold text-[#4CAF50]">{history.source}</p>
+                    </li>
+                  ))}
+                </ol>
+              )}
             </div>
 
             <aside className="rounded-lg border border-[#E5E7EB] bg-white p-5 shadow-sm">
               <p className="text-sm font-semibold text-[#F59E0B]">저장한 책</p>
               <h2 className="mt-2 text-xl font-bold text-[#1E2A38]">다음에 읽을 후보</h2>
-              <div className="mt-5 space-y-4">
-                {savedBooks.map((book) => (
-                  <div className="border-b border-[#E5E7EB] pb-4 last:border-b-0 last:pb-0" key={book.id}>
-                    <p className="font-semibold text-[#1E2A38]">{book.title}</p>
-                    <p className="mt-1 text-sm text-[#6B7280]">{book.author}</p>
-                    <p className="mt-2 text-xs font-semibold text-[#4CAF50]">{book.recommendationReason}</p>
-                  </div>
-                ))}
-              </div>
+              {!isLoading && savedBooks.length === 0 ? (
+                <div className="mt-5">
+                  <EmptyState
+                    actionLabel="읽을 책 찾기"
+                    message="나중에 읽을 책은 책 상세에서 저장할 수 있습니다."
+                    to="/rankings"
+                  />
+                </div>
+              ) : (
+                <div className="mt-5 space-y-4">
+                  {savedBooks.map((book) => (
+                    <div className="border-b border-[#E5E7EB] pb-4 last:border-b-0 last:pb-0" key={book.id}>
+                      <p className="font-semibold text-[#1E2A38]">{book.title}</p>
+                      <p className="mt-1 text-sm text-[#6B7280]">{book.author}</p>
+                      <p className="mt-2 text-xs font-semibold text-[#4CAF50]">{book.recommendationReason}</p>
+                    </div>
+                  ))}
+                </div>
+              )}
             </aside>
           </section>
         </div>

--- a/frontend/src/pages/OnboardingPage.jsx
+++ b/frontend/src/pages/OnboardingPage.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
-import { useNavigate } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom";
 import { useAuth } from "../App";
 
 function normalizeCategory(category) {
@@ -32,11 +32,13 @@ function getInitialBookIds(options, myPage) {
 
 export default function OnboardingPage() {
   const { accessToken, logout } = useAuth();
+  const location = useLocation();
   const navigate = useNavigate();
   const [availableCategories, setAvailableCategories] = useState([]);
   const [availableBooks, setAvailableBooks] = useState([]);
   const [selectedCategoryIds, setSelectedCategoryIds] = useState([]);
   const [selectedBookIds, setSelectedBookIds] = useState([]);
+  const [isEditMode, setIsEditMode] = useState(false);
   const [isLoading, setIsLoading] = useState(true);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [message, setMessage] = useState("");
@@ -44,6 +46,9 @@ export default function OnboardingPage() {
   const [canSave, setCanSave] = useState(false);
 
   const canSubmit = canSave && selectedCategoryIds.length > 0 && selectedBookIds.length > 0 && !isSubmitting;
+  const focusedSection = new URLSearchParams(location.search).get("section");
+  const isInterestFocused = focusedSection === "interests";
+  const isReadBooksFocused = focusedSection === "read-books";
 
   const selectedSummary = useMemo(
     () => ({
@@ -93,12 +98,15 @@ export default function OnboardingPage() {
         const nextBooks = (options.books ?? options.readableBooks ?? []).map(normalizeBook).filter((book) => book.id);
         const myPageResponse = await fetch("/api/me/mypage", { headers });
         const myPage = myPageResponse.ok ? await myPageResponse.json() : null;
+        const initialCategoryIds = getInitialCategoryIds(nextCategories, myPage);
+        const initialBookIds = getInitialBookIds(nextBooks, myPage);
 
         if (!ignore) {
           setAvailableCategories(nextCategories);
           setAvailableBooks(nextBooks);
-          setSelectedCategoryIds(getInitialCategoryIds(nextCategories, myPage));
-          setSelectedBookIds(getInitialBookIds(nextBooks, myPage));
+          setSelectedCategoryIds(initialCategoryIds);
+          setSelectedBookIds(initialBookIds);
+          setIsEditMode(initialCategoryIds.length > 0 || initialBookIds.length > 0);
           setCanSave(nextCategories.length > 0 && nextBooks.length > 0);
           if (nextCategories.length === 0 || nextBooks.length === 0) {
             setMessage("온보딩 선택지가 아직 준비되지 않았습니다. 잠시 후 다시 시도해 주세요.");
@@ -108,6 +116,7 @@ export default function OnboardingPage() {
         if (!ignore) {
           setAvailableCategories([]);
           setAvailableBooks([]);
+          setIsEditMode(false);
           setCanSave(false);
           setMessage("온보딩 선택지를 불러오지 못했습니다. 잠시 후 다시 시도해 주세요.");
         }
@@ -196,20 +205,29 @@ export default function OnboardingPage() {
       <form className="grid grid-cols-1 gap-6 lg:grid-cols-[1fr_340px]" onSubmit={submitOnboarding}>
         <div className="space-y-6">
           <div className="rounded-lg border border-[#E5E7EB] bg-white p-6 shadow-sm">
-            <p className="text-sm font-semibold text-[#4CAF50]">개인화 시작</p>
-            <h1 className="mt-3 text-3xl font-bold leading-tight text-[#1E2A38]">관심 분야와 읽은 책을 선택해 주세요</h1>
+            <p className="text-sm font-semibold text-[#4CAF50]">{isEditMode ? "취향 수정" : "개인화 시작"}</p>
+            <h1 className="mt-3 text-3xl font-bold leading-tight text-[#1E2A38]">
+              {isEditMode ? "관심 분야와 읽은 책을 다시 조정해 주세요" : "관심 분야와 읽은 책을 선택해 주세요"}
+            </h1>
             <p className="mt-4 max-w-2xl text-sm leading-6 text-[#6B7280]">
-              선택한 정보는 마이페이지와 추천 이유에 반영됩니다. 지금 고른 내용은 이후 취향 수정에서 다시 바꿀 수 있습니다.
+              {isEditMode
+                ? "현재 마이페이지에 반영된 취향을 불러왔습니다. 수정한 내용은 저장 후 추천 이유에 다시 반영됩니다."
+                : "선택한 정보는 마이페이지와 추천 이유에 반영됩니다. 지금 고른 내용은 이후 취향 수정에서 다시 바꿀 수 있습니다."}
             </p>
             {isLoading ? <p className="mt-4 text-sm text-[#6B7280]">온보딩 선택지를 불러오는 중입니다.</p> : null}
             {message ? <p className="mt-4 text-sm font-medium text-[#4CAF50]">{message}</p> : null}
           </div>
 
-          <section className="rounded-lg border border-[#E5E7EB] bg-white p-5 shadow-sm">
+          <section
+            className={`rounded-lg border bg-white p-5 shadow-sm ${
+              isInterestFocused ? "border-[#4CAF50] ring-2 ring-[#4CAF50]/20" : "border-[#E5E7EB]"
+            }`}
+          >
             <div className="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
               <div>
                 <p className="text-sm font-semibold text-[#1E2A38]">관심 분야</p>
                 <h2 className="mt-2 text-2xl font-bold text-[#1E2A38]">추천 기준이 되는 교양 필터</h2>
+                {isInterestFocused ? <p className="mt-2 text-sm text-[#4CAF50]">마이페이지에서 관심 분야 수정을 선택했습니다.</p> : null}
               </div>
               <span className="rounded-full bg-[#4CAF50]/10 px-3 py-2 text-xs font-semibold text-[#4CAF50]">
                 {selectedCategoryIds.length}개 선택
@@ -243,11 +261,16 @@ export default function OnboardingPage() {
             </div>
           </section>
 
-          <section className="rounded-lg border border-[#E5E7EB] bg-white p-5 shadow-sm">
+          <section
+            className={`rounded-lg border bg-white p-5 shadow-sm ${
+              isReadBooksFocused ? "border-[#F59E0B] ring-2 ring-[#F59E0B]/20" : "border-[#E5E7EB]"
+            }`}
+          >
             <div className="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
               <div>
                 <p className="text-sm font-semibold text-[#1E2A38]">읽은 책</p>
                 <h2 className="mt-2 text-2xl font-bold text-[#1E2A38]">취향 분석에 사용할 책</h2>
+                {isReadBooksFocused ? <p className="mt-2 text-sm text-[#B45309]">마이페이지에서 읽은 책 수정을 선택했습니다.</p> : null}
               </div>
               <span className="rounded-full bg-[#F59E0B]/10 px-3 py-2 text-xs font-semibold text-[#B45309]">
                 {selectedBookIds.length}권 선택
@@ -333,7 +356,7 @@ export default function OnboardingPage() {
             disabled={!canSubmit}
             type="submit"
           >
-            {isSubmitting ? "저장 중..." : "저장하고 마이페이지로"}
+            {isSubmitting ? "저장 중..." : isEditMode ? "수정하고 마이페이지로" : "저장하고 마이페이지로"}
           </button>
         </aside>
       </form>


### PR DESCRIPTION
## 📌 개요
> 어떤 변경 사항인지

- 마이페이지에서 사용자가 관심 분야와 읽은 책을 다시 수정할 수 있는 진입점을 추가했습니다.
- 비어 있는 마이페이지 섹션에 안내 문구와 다음 행동 버튼을 추가했습니다.
- 온보딩 페이지 재진입 시 신규 설정이 아닌 취향 수정 흐름임을 알 수 있도록 문구와 버튼 상태를 조정했습니다.

---

## 🔗 관련 이슈
- Closes #18

---

## ✨ 작업 내용
> 주요 변경 사항

### 🔹 Backend
- 변경 없음
- 기존 `GET /api/me/mypage`, `PUT /api/me/onboarding` 흐름을 그대로 사용

### 🔹 Frontend
- 마이페이지 관심 분야 섹션에 `관심 분야 수정` 링크 추가
- 마이페이지 읽은 책 섹션에 `읽은 책 수정` 링크 추가
- 관심 분야, 읽은 책, 저장한 책, 추천 히스토리 빈 상태 UI 추가
- 빈 상태별 다음 행동 버튼 추가
  - 관심 분야: `/onboarding?section=interests`
  - 읽은 책: `/onboarding?section=read-books`
  - 저장한 책: `/rankings`
  - 추천 히스토리: `/rankings`
- 온보딩 페이지에서 기존 선택값이 있으면 `취향 수정` 흐름으로 문구 변경
- 온보딩 저장 버튼 문구를 상황별로 변경
  - 신규 설정: `저장하고 마이페이지로`
  - 기존 취향 수정: `수정하고 마이페이지로`
- query string에 따라 온보딩의 관심 분야/읽은 책 섹션을 시각적으로 강조

---

## 🧪 테스트 결과
- [x] 로컬 테스트 완료
- [x] 프론트엔드 빌드 성공 (`npm run build`)
- [ ] API 정상 동작 확인
- [ ] 에러 케이스 확인
- [ ] 모바일/데스크톱 UI 수동 확인

---

## 📸 스크린샷 (선택)
> UI 변경 시 첨부

- 미첨부

---

## ⚠️ 주의사항
- Backend API와 DB schema 변경은 없습니다.
- 온보딩 query string 진입 시 자동 스크롤은 구현하지 않았고, 섹션 강조만 반영했습니다.
- 저장한 책 빈 상태는 현재 책 상세 저장 기능이 없으므로 `/rankings` 탐색으로만 연결했습니다.
- 온보딩 재진입 시 기존 선택값 로딩 전에는 잠깐 신규 설정 문구가 보일 수 있습니다.

---

## 🚀 배포 전 체크리스트
- [x] 빌드 성공 (`npm run build`)
- [ ] 환경변수 설정 확인
- [x] DB 영향 없음
- [x] Backend 변경 없음
- [ ] 실제 로그인 사용자 기준 마이페이지/온보딩 플로우 확인

---

## 💬 리뷰 포인트
> 리뷰어가 집중해서 봐야 할 부분

- 마이페이지 빈 상태 문구와 다음 행동 링크가 기획 의도와 맞는지
- `/onboarding?section=interests`, `/onboarding?section=read-books` 진입 시 강조 UX가 충분한지
- 온보딩 페이지를 취향 수정 화면으로 재사용하는 방식이 어색하지 않은지
- 로딩 중 빈 상태가 먼저 노출되지 않는지
