### PR TITLE
feat: 책 이미지 연동(Closes #24)

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,7 @@
+DB_URL=jdbc:mysql://localhost:3306/chaeklist?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
+DB_USERNAME=
+DB_PASSWORD=
+
+KAKAO_REST_API_KEY=
+KAKAO_BOOK_SEARCH_URL=https://dapi.kakao.com/v3/search/book
+BOOK_IMAGE_ENRICHMENT_KEY=

--- a/backend/scripts/init-env.ps1
+++ b/backend/scripts/init-env.ps1
@@ -1,0 +1,58 @@
+param(
+    [string] $EnvPath = (Join-Path $PSScriptRoot "..\.env")
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+function New-SecretValue {
+    $bytes = [byte[]]::new(32)
+    $generator = [System.Security.Cryptography.RandomNumberGenerator]::Create()
+    try {
+        $generator.GetBytes($bytes)
+    } finally {
+        $generator.Dispose()
+    }
+    return [Convert]::ToBase64String($bytes)
+}
+
+$resolvedEnvPath = [System.IO.Path]::GetFullPath($EnvPath)
+$envDirectory = Split-Path -Parent $resolvedEnvPath
+
+if (-not (Test-Path -LiteralPath $envDirectory)) {
+    New-Item -ItemType Directory -Force -Path $envDirectory | Out-Null
+}
+
+if (-not (Test-Path -LiteralPath $resolvedEnvPath)) {
+    New-Item -ItemType File -Path $resolvedEnvPath | Out-Null
+}
+
+$envLines = Get-Content -LiteralPath $resolvedEnvPath
+$keyPattern = "^\s*BOOK_IMAGE_ENRICHMENT_KEY\s*="
+$keyLine = $envLines | Where-Object { $_ -match $keyPattern } | Select-Object -First 1
+
+if ($null -eq $keyLine) {
+    if ($envLines.Count -gt 0 -and $envLines[-1].Trim() -ne "") {
+        Add-Content -LiteralPath $resolvedEnvPath -Value ""
+    }
+    Add-Content -LiteralPath $resolvedEnvPath -Value ("BOOK_IMAGE_ENRICHMENT_KEY=" + (New-SecretValue))
+    Write-Host "BOOK_IMAGE_ENRICHMENT_KEY was generated and added to $resolvedEnvPath"
+    exit 0
+}
+
+$currentValue = ($keyLine -split "=", 2)[1].Trim()
+if ([string]::IsNullOrWhiteSpace($currentValue)) {
+    $newSecret = New-SecretValue
+    $updatedLines = $envLines | ForEach-Object {
+        if ($_ -match $keyPattern) {
+            "BOOK_IMAGE_ENRICHMENT_KEY=$newSecret"
+        } else {
+            $_
+        }
+    }
+    Set-Content -LiteralPath $resolvedEnvPath -Value $updatedLines
+    Write-Host "BOOK_IMAGE_ENRICHMENT_KEY was generated in $resolvedEnvPath"
+    exit 0
+}
+
+Write-Host "BOOK_IMAGE_ENRICHMENT_KEY already exists in $resolvedEnvPath"

--- a/backend/src/main/java/com/example/chaeklist/domain/book/controller/BookController.java
+++ b/backend/src/main/java/com/example/chaeklist/domain/book/controller/BookController.java
@@ -5,8 +5,10 @@ import java.util.Map;
 
 import com.example.chaeklist.domain.auth.util.TokenService;
 import com.example.chaeklist.domain.book.dto.BookDetailResponse;
+import com.example.chaeklist.domain.book.dto.BookImageEnrichmentResponse;
 import com.example.chaeklist.domain.book.dto.BookSummaryResponse;
 import com.example.chaeklist.domain.book.dto.HomeResponse;
+import com.example.chaeklist.domain.book.service.BookImageEnrichmentService;
 import com.example.chaeklist.domain.book.service.BookService;
 import com.example.chaeklist.global.auth.AuthenticatedUser;
 import com.example.chaeklist.global.auth.BearerTokenResolver;
@@ -15,11 +17,13 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -29,12 +33,22 @@ import org.springframework.web.bind.annotation.RestController;
 public class BookController {
 
 	private final BearerTokenResolver bearerTokenResolver;
+	private final BookImageEnrichmentService bookImageEnrichmentService;
 	private final BookService bookService;
+	private final String bookImageEnrichmentKey;
 	private final TokenService tokenService;
 
-	public BookController(BearerTokenResolver bearerTokenResolver, BookService bookService, TokenService tokenService) {
+	public BookController(
+			BearerTokenResolver bearerTokenResolver,
+			BookImageEnrichmentService bookImageEnrichmentService,
+			BookService bookService,
+			@Value("${BOOK_IMAGE_ENRICHMENT_KEY:}") String bookImageEnrichmentKey,
+			TokenService tokenService
+	) {
 		this.bearerTokenResolver = bearerTokenResolver;
+		this.bookImageEnrichmentService = bookImageEnrichmentService;
 		this.bookService = bookService;
+		this.bookImageEnrichmentKey = bookImageEnrichmentKey;
 		this.tokenService = tokenService;
 	}
 
@@ -112,6 +126,28 @@ public class BookController {
 				.orElseGet(() -> bookService.getBookDetail(bookId));
 	}
 
+	@PostMapping("/api/books/images/enrich")
+	@Operation(summary = "책 표지 이미지 일괄 보강", description = "cover_image_url이 비어 있는 책을 Kakao 도서 검색 API로 보강합니다.")
+	@ApiResponse(responseCode = "200", description = "이미지 보강 실행 완료")
+	@ApiResponse(responseCode = "401", description = "실행 키 누락 또는 불일치")
+	@ApiResponse(responseCode = "503", description = "이미지 보강 설정 누락")
+	public BookImageEnrichmentResponse enrichBookImages(
+			@Parameter(hidden = true) @RequestHeader(value = "X-Book-Image-Enrichment-Key", required = false) String enrichmentKey,
+			@Parameter(description = "한 번에 처리할 책 수. 최대 50", example = "20") @RequestParam(defaultValue = "20") int limit
+	) {
+		validateBookImageEnrichmentKey(enrichmentKey);
+		return bookImageEnrichmentService.enrichMissingCoverImages(limit);
+	}
+
+	private void validateBookImageEnrichmentKey(String enrichmentKey) {
+		if (bookImageEnrichmentKey == null || bookImageEnrichmentKey.isBlank()) {
+			throw new BookImageEnrichmentService.BookImageEnrichmentException("BOOK_IMAGE_ENRICHMENT_KEY is required.");
+		}
+		if (!bookImageEnrichmentKey.equals(enrichmentKey)) {
+			throw new UnauthorizedException("Invalid book image enrichment key.");
+		}
+	}
+
 	@ExceptionHandler(UnauthorizedException.class)
 	public ResponseEntity<Map<String, String>> handleUnauthorized(UnauthorizedException exception) {
 		return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(Map.of("message", exception.getMessage()));
@@ -130,6 +166,13 @@ public class BookController {
 	@ExceptionHandler(BookService.BookRequestException.class)
 	public ResponseEntity<Map<String, String>> handleBadRequest(BookService.BookRequestException exception) {
 		return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(Map.of("message", exception.getMessage()));
+	}
+
+	@ExceptionHandler(BookImageEnrichmentService.BookImageEnrichmentException.class)
+	public ResponseEntity<Map<String, String>> handleBookImageEnrichmentError(
+			BookImageEnrichmentService.BookImageEnrichmentException exception
+	) {
+		return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE).body(Map.of("message", exception.getMessage()));
 	}
 
 	static class UnauthorizedException extends RuntimeException {

--- a/backend/src/main/java/com/example/chaeklist/domain/book/dto/BookDetailResponse.java
+++ b/backend/src/main/java/com/example/chaeklist/domain/book/dto/BookDetailResponse.java
@@ -13,6 +13,8 @@ public record BookDetailResponse(
 		String title,
 		@Schema(description = "저자", example = "문서윤")
 		String author,
+		@Schema(description = "책 표지 이미지 URL", example = "https://example.com/book-cover.jpg", nullable = true)
+		String imageUrl,
 		@Schema(description = "카테고리", example = "인문")
 		String category,
 		@Schema(description = "책 태그", example = "교양 필터 통과")
@@ -48,6 +50,7 @@ public record BookDetailResponse(
 				book.id(),
 				book.title(),
 				book.author(),
+				book.coverImageUrl(),
 				book.category(),
 				book.tag(),
 				book.summary(),

--- a/backend/src/main/java/com/example/chaeklist/domain/book/dto/BookImageEnrichmentResponse.java
+++ b/backend/src/main/java/com/example/chaeklist/domain/book/dto/BookImageEnrichmentResponse.java
@@ -1,0 +1,16 @@
+package com.example.chaeklist.domain.book.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "책 표지 이미지 보강 결과")
+public record BookImageEnrichmentResponse(
+		@Schema(description = "보강 대상으로 조회한 책 수", example = "20")
+		int processed,
+		@Schema(description = "이미지 URL 저장 성공 수", example = "15")
+		int updated,
+		@Schema(description = "검색 결과가 없거나 매칭 실패한 수", example = "4")
+		int skipped,
+		@Schema(description = "외부 API 호출 또는 저장 실패 수", example = "1")
+		int failed
+) {
+}

--- a/backend/src/main/java/com/example/chaeklist/domain/book/dto/BookSummaryResponse.java
+++ b/backend/src/main/java/com/example/chaeklist/domain/book/dto/BookSummaryResponse.java
@@ -24,6 +24,8 @@ public record BookSummaryResponse(
 		String title,
 		@Schema(description = "저자", example = "문서윤")
 		String author,
+		@Schema(description = "책 표지 이미지 URL", example = "https://example.com/book-cover.jpg", nullable = true)
+		String imageUrl,
 		@Schema(description = "카테고리", example = "인문")
 		String category,
 		@Schema(description = "책 태그", example = "교양 필터 통과")
@@ -50,6 +52,7 @@ public record BookSummaryResponse(
 				null,
 				book.title(),
 				book.author(),
+				book.coverImageUrl(),
 				book.category(),
 				book.tag(),
 				book.views(),
@@ -68,6 +71,7 @@ public record BookSummaryResponse(
 				snapshot.rankDate(),
 				book.title(),
 				book.author(),
+				book.coverImageUrl(),
 				book.category(),
 				book.tag(),
 				formatCount(snapshot.viewCount()),

--- a/backend/src/main/java/com/example/chaeklist/domain/book/entity/Book.java
+++ b/backend/src/main/java/com/example/chaeklist/domain/book/entity/Book.java
@@ -106,6 +106,10 @@ public class Book {
 		return author;
 	}
 
+	public String coverImageUrl() {
+		return coverImageUrl;
+	}
+
 	public String category() {
 		return categories.stream()
 				.min(Comparator.comparingInt(Category::displayOrder))

--- a/backend/src/main/java/com/example/chaeklist/domain/book/service/BookImageEnrichmentService.java
+++ b/backend/src/main/java/com/example/chaeklist/domain/book/service/BookImageEnrichmentService.java
@@ -1,0 +1,170 @@
+package com.example.chaeklist.domain.book.service;
+
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.Optional;
+
+import com.example.chaeklist.domain.book.dto.BookImageEnrichmentResponse;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClientException;
+
+@Service
+public class BookImageEnrichmentService {
+
+	private static final int DEFAULT_LIMIT = 20;
+	private static final int MAX_LIMIT = 50;
+
+	private final String kakaoApiKey;
+	private final String kakaoBookSearchUrl;
+	private final JdbcTemplate jdbcTemplate;
+	private final RestClient restClient;
+
+	public BookImageEnrichmentService(
+			@Value("${KAKAO_REST_API_KEY:}") String kakaoApiKey,
+			@Value("${KAKAO_BOOK_SEARCH_URL:https://dapi.kakao.com/v3/search/book}") String kakaoBookSearchUrl,
+			JdbcTemplate jdbcTemplate,
+			RestClient.Builder restClientBuilder
+	) {
+		this.kakaoApiKey = kakaoApiKey;
+		this.kakaoBookSearchUrl = kakaoBookSearchUrl;
+		this.jdbcTemplate = jdbcTemplate;
+		this.restClient = restClientBuilder.build();
+	}
+
+	public BookImageEnrichmentResponse enrichMissingCoverImages(int requestedLimit) {
+		if (kakaoApiKey == null || kakaoApiKey.isBlank()) {
+			throw new BookImageEnrichmentException("KAKAO_REST_API_KEY is required.");
+		}
+
+		List<BookImageTarget> targets = findTargets(normalizeLimit(requestedLimit));
+		int updated = 0;
+		int skipped = 0;
+		int failed = 0;
+
+		for (BookImageTarget target : targets) {
+			try {
+				Optional<String> imageUrl = searchCoverImageUrl(target);
+				if (imageUrl.isEmpty()) {
+					skipped++;
+					continue;
+				}
+				updated += updateCoverImageUrl(target.id(), imageUrl.get());
+			} catch (RestClientException exception) {
+				failed++;
+			}
+		}
+
+		return new BookImageEnrichmentResponse(targets.size(), updated, skipped, failed);
+	}
+
+	private List<BookImageTarget> findTargets(int limit) {
+		return jdbcTemplate.query("""
+				SELECT id, title, author, isbn13
+				FROM books
+				WHERE is_general_eligible = TRUE
+					AND (cover_image_url IS NULL OR cover_image_url = '')
+				ORDER BY id ASC
+				LIMIT ?
+				""",
+				(resultSet, rowNumber) -> new BookImageTarget(
+						resultSet.getLong("id"),
+						resultSet.getString("title"),
+						resultSet.getString("author"),
+						resultSet.getString("isbn13")
+				),
+				limit
+		);
+	}
+
+	private Optional<String> searchCoverImageUrl(BookImageTarget target) {
+		KakaoBookSearchResponse response = restClient.get()
+				.uri(kakaoBookSearchUrl, uriBuilder -> uriBuilder
+						.queryParam("query", searchQuery(target))
+						.queryParam("size", 10)
+						.build())
+				.header("Authorization", "KakaoAK " + kakaoApiKey)
+				.retrieve()
+				.body(KakaoBookSearchResponse.class);
+
+		if (response == null || response.documents() == null) {
+			return Optional.empty();
+		}
+
+		return response.documents().stream()
+				.filter(document -> document.thumbnail() != null && !document.thumbnail().isBlank())
+				.sorted((first, second) -> Integer.compare(matchScore(second, target), matchScore(first, target)))
+				.map(KakaoBookDocument::thumbnail)
+				.findFirst();
+	}
+
+	private String searchQuery(BookImageTarget target) {
+		if (target.isbn13() != null && !target.isbn13().isBlank()) {
+			return target.isbn13();
+		}
+		return target.title() + " " + target.author();
+	}
+
+	private int updateCoverImageUrl(long bookId, String imageUrl) {
+		return jdbcTemplate.update("""
+				UPDATE books
+				SET cover_image_url = ?,
+					source_provider = COALESCE(NULLIF(source_provider, ''), 'KAKAO'),
+					updated_at = CURRENT_TIMESTAMP
+				WHERE id = ?
+					AND (cover_image_url IS NULL OR cover_image_url = '')
+				""", imageUrl, bookId);
+	}
+
+	private int matchScore(KakaoBookDocument document, BookImageTarget target) {
+		int score = 0;
+		String documentTitle = normalize(document.title());
+		String targetTitle = normalize(target.title());
+		if (!targetTitle.isBlank() && documentTitle.contains(targetTitle)) {
+			score += 60;
+		}
+		if (!targetTitle.isBlank() && targetTitle.contains(documentTitle)) {
+			score += 30;
+		}
+		if (document.authors() != null && document.authors().stream()
+				.filter(Objects::nonNull)
+				.map(this::normalize)
+				.anyMatch(author -> !author.isBlank() && normalize(target.author()).contains(author))) {
+			score += 40;
+		}
+		return score;
+	}
+
+	private String normalize(String value) {
+		if (value == null) {
+			return "";
+		}
+		return value.toLowerCase(Locale.ROOT).replaceAll("[\\s\\p{Punct}]", "");
+	}
+
+	private int normalizeLimit(int limit) {
+		if (limit <= 0) {
+			return DEFAULT_LIMIT;
+		}
+		return Math.min(limit, MAX_LIMIT);
+	}
+
+	public static class BookImageEnrichmentException extends RuntimeException {
+
+		public BookImageEnrichmentException(String message) {
+			super(message);
+		}
+	}
+
+	private record BookImageTarget(long id, String title, String author, String isbn13) {
+	}
+
+	private record KakaoBookSearchResponse(List<KakaoBookDocument> documents) {
+	}
+
+	private record KakaoBookDocument(String title, List<String> authors, String thumbnail) {
+	}
+}

--- a/backend/src/main/java/com/example/chaeklist/domain/book/service/BookImagePredeployRunner.java
+++ b/backend/src/main/java/com/example/chaeklist/domain/book/service/BookImagePredeployRunner.java
@@ -5,6 +5,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.ApplicationArguments;
 import org.springframework.boot.ApplicationRunner;
+import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -14,13 +15,20 @@ public class BookImagePredeployRunner implements ApplicationRunner {
 	private static final int PREDEPLOY_LIMIT = 50;
 
 	private final BookImageEnrichmentService bookImageEnrichmentService;
+	private final JdbcTemplate jdbcTemplate;
 
-	public BookImagePredeployRunner(BookImageEnrichmentService bookImageEnrichmentService) {
+	public BookImagePredeployRunner(BookImageEnrichmentService bookImageEnrichmentService, JdbcTemplate jdbcTemplate) {
 		this.bookImageEnrichmentService = bookImageEnrichmentService;
+		this.jdbcTemplate = jdbcTemplate;
 	}
 
 	@Override
 	public void run(ApplicationArguments args) {
+		int seededCoverUrls = applySeedCoverUrls();
+		if (seededCoverUrls > 0) {
+			log.info("Seed book cover URLs applied. updated={}", seededCoverUrls);
+		}
+
 		try {
 			BookImageEnrichmentResponse response = bookImageEnrichmentService.enrichMissingCoverImages(PREDEPLOY_LIMIT);
 			log.info(
@@ -35,5 +43,28 @@ public class BookImagePredeployRunner implements ApplicationRunner {
 		} catch (RuntimeException exception) {
 			log.warn("Book image predeploy failed.", exception);
 		}
+	}
+
+	private int applySeedCoverUrls() {
+		int updated = 0;
+		updated += updateSeedCoverUrl("dummy-atomic-habits", "/book-covers/atomic-habits.svg");
+		updated += updateSeedCoverUrl("slow-reading", "/book-covers/slow-reading.svg");
+		updated += updateSeedCoverUrl("quiet-investing", "/book-covers/quiet-investing.svg");
+		updated += updateSeedCoverUrl("attention-design", "/book-covers/attention-design.svg");
+		updated += updateSeedCoverUrl("small-city", "/book-covers/small-city.svg");
+		updated += updateSeedCoverUrl("daily-sentence", "/book-covers/daily-sentence.svg");
+		updated += updateSeedCoverUrl("excluded-economics-test", "/book-covers/excluded-economics-test.svg");
+		return updated;
+	}
+
+	private int updateSeedCoverUrl(String sourceBookId, String coverImageUrl) {
+		return jdbcTemplate.update("""
+				UPDATE books
+				SET cover_image_url = ?,
+					updated_at = CURRENT_TIMESTAMP
+				WHERE source_book_id = ?
+					AND source_provider IN ('LOCAL', 'DUMMY')
+					AND (cover_image_url IS NULL OR cover_image_url = '')
+				""", coverImageUrl, sourceBookId);
 	}
 }

--- a/backend/src/main/java/com/example/chaeklist/domain/book/service/BookImagePredeployRunner.java
+++ b/backend/src/main/java/com/example/chaeklist/domain/book/service/BookImagePredeployRunner.java
@@ -1,0 +1,39 @@
+package com.example.chaeklist.domain.book.service;
+
+import com.example.chaeklist.domain.book.dto.BookImageEnrichmentResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.stereotype.Component;
+
+@Component
+public class BookImagePredeployRunner implements ApplicationRunner {
+
+	private static final Logger log = LoggerFactory.getLogger(BookImagePredeployRunner.class);
+	private static final int PREDEPLOY_LIMIT = 50;
+
+	private final BookImageEnrichmentService bookImageEnrichmentService;
+
+	public BookImagePredeployRunner(BookImageEnrichmentService bookImageEnrichmentService) {
+		this.bookImageEnrichmentService = bookImageEnrichmentService;
+	}
+
+	@Override
+	public void run(ApplicationArguments args) {
+		try {
+			BookImageEnrichmentResponse response = bookImageEnrichmentService.enrichMissingCoverImages(PREDEPLOY_LIMIT);
+			log.info(
+					"Book image predeploy completed. processed={}, updated={}, skipped={}, failed={}",
+					response.processed(),
+					response.updated(),
+					response.skipped(),
+					response.failed()
+			);
+		} catch (BookImageEnrichmentService.BookImageEnrichmentException exception) {
+			log.warn("Book image predeploy skipped. {}", exception.getMessage());
+		} catch (RuntimeException exception) {
+			log.warn("Book image predeploy failed.", exception);
+		}
+	}
+}

--- a/backend/src/main/java/com/example/chaeklist/domain/mypage/dto/MyPageBookResponse.java
+++ b/backend/src/main/java/com/example/chaeklist/domain/mypage/dto/MyPageBookResponse.java
@@ -12,6 +12,8 @@ public record MyPageBookResponse(
 		String title,
 		@Schema(description = "저자", example = "문서윤")
 		String author,
+		@Schema(description = "책 표지 이미지 URL", example = "https://example.com/book-cover.jpg", nullable = true)
+		String imageUrl,
 		@Schema(description = "카테고리", example = "인문")
 		String category,
 		@Schema(description = "교양 필터 또는 상태 태그", example = "교양 필터 통과")

--- a/backend/src/main/java/com/example/chaeklist/domain/mypage/service/MyPageService.java
+++ b/backend/src/main/java/com/example/chaeklist/domain/mypage/service/MyPageService.java
@@ -341,6 +341,7 @@ public class MyPageService {
 					b.id,
 					b.title,
 					b.author,
+					b.cover_image_url,
 					COALESCE(primary_category.name, '미분류') AS category_name,
 					COALESCE(NULLIF(b.filter_reason, ''), '교양 필터 통과') AS tag,
 					COUNT(DISTINCT view_interactions.id) AS view_count,
@@ -359,7 +360,7 @@ public class MyPageService {
 				WHERE ubi.user_id = ?
 					AND ubi.interaction_type = ?
 					AND b.is_general_eligible = TRUE
-				GROUP BY b.id, b.title, b.author, primary_category.name, primary_category.display_order, b.filter_reason
+				GROUP BY b.id, b.title, b.author, b.cover_image_url, primary_category.name, primary_category.display_order, b.filter_reason
 				ORDER BY MAX(ubi.created_at) DESC, b.id DESC
 				LIMIT ?
 				""",
@@ -376,6 +377,7 @@ public class MyPageService {
 					b.id,
 					b.title,
 					b.author,
+					b.cover_image_url,
 					COALESCE(primary_category.name, '미분류') AS category_name,
 					COALESCE(NULLIF(b.filter_reason, ''), '교양 필터 통과') AS tag,
 					COUNT(DISTINCT view_interactions.id) AS view_count,
@@ -406,7 +408,7 @@ public class MyPageService {
 					AND save_interactions.interaction_type = 'SAVE'
 					AND later_unsave.id IS NULL
 					AND b.is_general_eligible = TRUE
-				GROUP BY b.id, b.title, b.author, primary_category.name, primary_category.display_order, b.filter_reason
+				GROUP BY b.id, b.title, b.author, b.cover_image_url, primary_category.name, primary_category.display_order, b.filter_reason
 				ORDER BY MAX(save_interactions.created_at) DESC, b.id DESC
 				LIMIT ?
 				""",
@@ -414,6 +416,7 @@ public class MyPageService {
 						resultSet.getString("id"),
 						resultSet.getString("title"),
 						resultSet.getString("author"),
+						resultSet.getString("cover_image_url"),
 						resultSet.getString("category_name"),
 						resultSet.getString("tag"),
 						formatCount(resultSet.getInt("view_count")),
@@ -463,6 +466,7 @@ public class MyPageService {
 				resultSet.getString("id"),
 				resultSet.getString("title"),
 				resultSet.getString("author"),
+				resultSet.getString("cover_image_url"),
 				category,
 				resultSet.getString("tag"),
 				formatCount(resultSet.getInt("view_count")),

--- a/frontend/public/book-covers/atomic-habits.svg
+++ b/frontend/public/book-covers/atomic-habits.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="240" height="320" viewBox="0 0 240 320" role="img" aria-label="Atomic Habits book cover">
+  <rect width="240" height="320" rx="18" fill="#f8fafc"/>
+  <rect x="18" y="18" width="204" height="284" rx="12" fill="#f59e0b"/>
+  <circle cx="188" cy="72" r="28" fill="#111827" opacity=".16"/>
+  <path d="M54 220h132" stroke="#111827" stroke-width="10" stroke-linecap="round" opacity=".25"/>
+  <path d="M54 244h88" stroke="#111827" stroke-width="10" stroke-linecap="round" opacity=".25"/>
+  <text x="38" y="86" fill="#111827" font-family="Arial, sans-serif" font-size="22" font-weight="700">ATOMIC</text>
+  <text x="38" y="114" fill="#111827" font-family="Arial, sans-serif" font-size="22" font-weight="700">HABITS</text>
+  <text x="38" y="154" fill="#111827" font-family="Arial, sans-serif" font-size="13" font-weight="700">small systems</text>
+  <text x="38" y="174" fill="#111827" font-family="Arial, sans-serif" font-size="13" font-weight="700">big change</text>
+</svg>

--- a/frontend/public/book-covers/attention-design.svg
+++ b/frontend/public/book-covers/attention-design.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="240" height="320" viewBox="0 0 240 320" role="img" aria-label="Attention Design book cover">
+  <rect width="240" height="320" rx="18" fill="#fff7ed"/>
+  <rect x="18" y="18" width="204" height="284" rx="12" fill="#f97316"/>
+  <circle cx="120" cy="126" r="54" fill="none" stroke="#ffffff" stroke-width="12" opacity=".85"/>
+  <circle cx="120" cy="126" r="16" fill="#1e2a38"/>
+  <path d="M120 56v-24M120 220v-24M50 126H26M214 126h-24" stroke="#1e2a38" stroke-width="8" stroke-linecap="round" opacity=".35"/>
+  <text x="34" y="244" fill="#111827" font-family="Arial, sans-serif" font-size="21" font-weight="700">ATTENTION</text>
+  <text x="34" y="272" fill="#111827" font-family="Arial, sans-serif" font-size="21" font-weight="700">DESIGN</text>
+</svg>

--- a/frontend/public/book-covers/daily-sentence.svg
+++ b/frontend/public/book-covers/daily-sentence.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="240" height="320" viewBox="0 0 240 320" role="img" aria-label="Daily Sentence book cover">
+  <rect width="240" height="320" rx="18" fill="#f3f4f6"/>
+  <rect x="18" y="18" width="204" height="284" rx="12" fill="#9ca3af"/>
+  <rect x="48" y="68" width="144" height="184" rx="8" fill="#ffffff" opacity=".82"/>
+  <path d="M70 114h100M70 146h78M70 178h94M70 210h66" stroke="#1e2a38" stroke-width="8" stroke-linecap="round" opacity=".55"/>
+  <text x="44" y="284" fill="#111827" font-family="Arial, sans-serif" font-size="20" font-weight="700">DAILY SENTENCE</text>
+</svg>

--- a/frontend/public/book-covers/excluded-economics-test.svg
+++ b/frontend/public/book-covers/excluded-economics-test.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="240" height="320" viewBox="0 0 240 320" role="img" aria-label="Economics test prep book cover">
+  <rect width="240" height="320" rx="18" fill="#f1f5f9"/>
+  <rect x="18" y="18" width="204" height="284" rx="12" fill="#64748b"/>
+  <rect x="42" y="58" width="156" height="52" rx="8" fill="#ffffff" opacity=".9"/>
+  <text x="60" y="92" fill="#111827" font-family="Arial, sans-serif" font-size="24" font-weight="700">1000</text>
+  <path d="M54 150h132M54 182h132M54 214h92" stroke="#ffffff" stroke-width="10" stroke-linecap="round" opacity=".75"/>
+  <text x="42" y="266" fill="#ffffff" font-family="Arial, sans-serif" font-size="20" font-weight="700">ECONOMICS</text>
+  <text x="42" y="290" fill="#ffffff" font-family="Arial, sans-serif" font-size="16" font-weight="700">TEST PREP</text>
+</svg>

--- a/frontend/public/book-covers/quiet-investing.svg
+++ b/frontend/public/book-covers/quiet-investing.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="240" height="320" viewBox="0 0 240 320" role="img" aria-label="Quiet Investing book cover">
+  <rect width="240" height="320" rx="18" fill="#f0fdf4"/>
+  <rect x="18" y="18" width="204" height="284" rx="12" fill="#16a34a"/>
+  <path d="M54 220c34-78 72-112 132-136" fill="none" stroke="#ffffff" stroke-width="12" stroke-linecap="round"/>
+  <path d="M54 220h132" stroke="#111827" stroke-width="8" stroke-linecap="round" opacity=".28"/>
+  <circle cx="80" cy="178" r="10" fill="#111827" opacity=".35"/>
+  <circle cx="124" cy="132" r="10" fill="#111827" opacity=".35"/>
+  <circle cx="174" cy="92" r="10" fill="#111827" opacity=".35"/>
+  <text x="34" y="72" fill="#111827" font-family="Arial, sans-serif" font-size="22" font-weight="700">QUIET</text>
+  <text x="34" y="100" fill="#111827" font-family="Arial, sans-serif" font-size="22" font-weight="700">INVESTING</text>
+</svg>

--- a/frontend/public/book-covers/slow-reading.svg
+++ b/frontend/public/book-covers/slow-reading.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="240" height="320" viewBox="0 0 240 320" role="img" aria-label="Slow Reading book cover">
+  <rect width="240" height="320" rx="18" fill="#f8fafc"/>
+  <rect x="18" y="18" width="204" height="284" rx="12" fill="#1e2a38"/>
+  <path d="M58 88h124M58 120h96M58 152h124M58 184h78" stroke="#ffffff" stroke-width="9" stroke-linecap="round" opacity=".78"/>
+  <circle cx="174" cy="216" r="28" fill="#4caf50"/>
+  <path d="M162 216h24M174 204v24" stroke="#ffffff" stroke-width="7" stroke-linecap="round"/>
+  <text x="36" y="266" fill="#ffffff" font-family="Arial, sans-serif" font-size="22" font-weight="700">SLOW</text>
+  <text x="36" y="292" fill="#ffffff" font-family="Arial, sans-serif" font-size="22" font-weight="700">READING</text>
+</svg>

--- a/frontend/public/book-covers/small-city.svg
+++ b/frontend/public/book-covers/small-city.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="240" height="320" viewBox="0 0 240 320" role="img" aria-label="Small City book cover">
+  <rect width="240" height="320" rx="18" fill="#f3f4f6"/>
+  <rect x="18" y="18" width="204" height="284" rx="12" fill="#6b7280"/>
+  <rect x="48" y="150" width="30" height="92" fill="#1e2a38"/>
+  <rect x="90" y="116" width="42" height="126" fill="#1e2a38"/>
+  <rect x="146" y="138" width="46" height="104" fill="#1e2a38"/>
+  <circle cx="176" cy="78" r="22" fill="#f9fafb" opacity=".9"/>
+  <path d="M44 260h152" stroke="#ffffff" stroke-width="8" stroke-linecap="round" opacity=".7"/>
+  <text x="36" y="70" fill="#ffffff" font-family="Arial, sans-serif" font-size="21" font-weight="700">SMALL CITY</text>
+  <text x="36" y="96" fill="#ffffff" font-family="Arial, sans-serif" font-size="21" font-weight="700">NIGHT</text>
+</svg>

--- a/frontend/src/components/BookCard.jsx
+++ b/frontend/src/components/BookCard.jsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
 
 export default function BookCard({ book, rank, variant = "default" }) {
@@ -6,6 +7,13 @@ export default function BookCard({ book, rank, variant = "default" }) {
   const growth = book.growth ?? book.growthRate;
   const views = book.views ?? "0";
   const saves = book.saves ?? 0;
+  const imageUrl = book.imageUrl;
+  const [imageFailed, setImageFailed] = useState(false);
+  const showImage = imageUrl && !imageFailed;
+
+  useEffect(() => {
+    setImageFailed(false);
+  }, [imageUrl]);
 
   return (
     <Link
@@ -13,9 +21,19 @@ export default function BookCard({ book, rank, variant = "default" }) {
       to={`/books/${book.id}`}
     >
       <div className="flex gap-4">
-        <div className={`flex h-32 w-24 shrink-0 items-end rounded-md ${cover} p-3 text-xs font-semibold text-white shadow-sm`}>
-          {displayRank ? `TOP ${displayRank}` : book.category}
-        </div>
+        {showImage ? (
+          <img
+            alt={`${book.title} 표지`}
+            className="h-32 w-24 shrink-0 rounded-md object-cover shadow-sm"
+            loading="lazy"
+            onError={() => setImageFailed(true)}
+            src={imageUrl}
+          />
+        ) : (
+          <div className={`flex h-32 w-24 shrink-0 items-end rounded-md ${cover} p-3 text-xs font-semibold text-white shadow-sm`}>
+            {displayRank ? `TOP ${displayRank}` : book.category}
+          </div>
+        )}
         <div className="min-w-0 flex-1">
           <div className="flex items-center gap-2">
             {displayRank ? <span className="text-sm font-bold text-[#F59E0B]">{displayRank}</span> : null}

--- a/frontend/src/pages/BookDetailPage.jsx
+++ b/frontend/src/pages/BookDetailPage.jsx
@@ -51,6 +51,7 @@ export default function BookDetailPage() {
   const [errorMessage, setErrorMessage] = useState("");
   const [actionMessage, setActionMessage] = useState("");
   const [pendingAction, setPendingAction] = useState("");
+  const [detailImageFailed, setDetailImageFailed] = useState(false);
 
   useEffect(() => {
     let ignore = false;
@@ -104,6 +105,10 @@ export default function BookDetailPage() {
       ignore = true;
     };
   }, [accessToken, bookId, fallbackBook, isAuthReady, logout]);
+
+  useEffect(() => {
+    setDetailImageFailed(false);
+  }, [book?.imageUrl]);
 
   async function saveInteraction(type) {
     if (!accessToken || !currentUser) {
@@ -198,6 +203,7 @@ export default function BookDetailPage() {
 
   const similarBooks = book.similarBooks?.length ? book.similarBooks : fallbackSimilarBooks;
   const isActionDisabled = Boolean(pendingAction) || !isAuthReady;
+  const showDetailImage = book.imageUrl && !detailImageFailed;
 
   return (
     <section className="mx-auto w-full max-w-6xl px-5 py-8">
@@ -212,9 +218,18 @@ export default function BookDetailPage() {
       ) : null}
 
       <div className="mt-5 grid grid-cols-1 gap-6 rounded-lg border border-[#E5E7EB] bg-white p-6 shadow-sm md:grid-cols-[240px_1fr]">
-        <div className={`flex aspect-[3/4] items-end rounded-lg ${book.cover} p-5 text-lg font-bold text-white shadow-sm`}>
-          {book.category}
-        </div>
+        {showDetailImage ? (
+          <img
+            alt={`${book.title} 표지`}
+            className="aspect-[3/4] w-full rounded-lg object-cover shadow-sm"
+            onError={() => setDetailImageFailed(true)}
+            src={book.imageUrl}
+          />
+        ) : (
+          <div className={`flex aspect-[3/4] items-end rounded-lg ${book.cover} p-5 text-lg font-bold text-white shadow-sm`}>
+            {book.category}
+          </div>
+        )}
         <div>
           <p className="text-sm font-semibold text-[#4CAF50]">{book.tag}</p>
           <h1 className="mt-3 text-3xl font-bold leading-tight text-[#1E2A38]">{book.title}</h1>


### PR DESCRIPTION
## 📌 개요
> 어떤 변경 사항인지

- 책 카드/상세/마이페이지에서 실제 책 표지 이미지를 표시하도록 이미지 URL 연동 및 fallback 처리를 구현
- Kakao 도서 검색 API를 이용해 비어 있는 책 표지 URL을 보강하고 DB에 캐싱
- seed/dummy 책 데이터에 대해서는 로컬 표지 이미지를 제공해 사이트 접속 직후 표지가 보이도록 처리

---

## 🔗 관련 이슈
- Closes #24 

---

## ✨ 작업 내용
> 주요 변경 사항

### 🔹 Backend
- `Book` 엔티티에 `coverImageUrl` 매핑 추가
- `BookSummaryResponse`, `BookDetailResponse`, `MyPageBookResponse`에 `imageUrl` 필드 추가
- Kakao 도서 검색 API 기반 책 표지 이미지 보강 서비스 추가
- `POST /api/books/images/enrich` 이미지 일괄 보강 API 추가
- `BOOK_IMAGE_ENRICHMENT_KEY` 기반 보강 API 실행 키 검증 추가
- 서버 시작 시 `cover_image_url`이 비어 있는 책을 사전 보강하는 predeploy runner 추가
- seed/dummy 책 데이터에 대해서 로컬 표지 URL을 자동 주입하도록 처리
- `.env.example` 및 `BOOK_IMAGE_ENRICHMENT_KEY` 자동 생성 스크립트 추가

### 🔹 Frontend
- `BookCard`에서 `imageUrl`이 있으면 `<img>`로 표지 표시
- 이미지가 없거나 로드 실패 시 기존 카테고리 색상 표지로 fallback
- `BookDetailPage`에서 책 상세 표지 이미지 표시 및 실패 fallback 처리
- seed/dummy 책용 로컬 SVG 표지 이미지 추가

---

## 🧪 테스트 결과
- [x] 로컬 테스트 완료
  - `backend`: `.\gradlew.bat test` 성공
  - `frontend`: `npm run build` 성공
- [x] API 정상 동작 확인
  - 기존 홈/랭킹/상세/마이페이지 응답에 `imageUrl` 필드가 포함되도록 구현
  - `cover_image_url`이 있는 책은 프론트에서 이미지로 표시
- [x] 에러 케이스 확인
  - 이미지 URL이 없을 경우 기존 색상 표지 fallback 표시
  - 이미지 로드 실패 시 fallback 표시
  - 보강 API key 누락/불일치 시 오류 응답 처리

---

## 📸 스크린샷 (선택)
> UI 변경 시 첨부

- 책 카드 및 상세 화면에서 표지 이미지 표시 확인 필요
- 이미지 없는 책은 기존 fallback 표지 유지

---

## ⚠️ 주의사항
- `KAKAO_REST_API_KEY` 환경변수가 설정되어야 Kakao 표지 보강이 동작함
- `BOOK_IMAGE_ENRICHMENT_KEY`는 `backend/scripts/init-env.ps1`로 자동 생성 가능
- 실제 secret이 들어가는 `backend/.env`는 Git에 포함하지 않음
- 외부 Kakao 이미지 URL은 추후 만료되거나 접근 불가할 수 있음
- seed/dummy 책은 외부 API 매칭이 어려워 로컬 SVG 표지 URL을 사용함

---

## 🚀 배포 전 체크리스트
- [x] 빌드 성공 (`npm run build`, `./gradlew test`)
- [x] 환경변수 설정 확인
  - `DB_URL`
  - `DB_USERNAME`
  - `DB_PASSWORD`
  - `KAKAO_REST_API_KEY`
  - `BOOK_IMAGE_ENRICHMENT_KEY`
  - `KAKAO_BOOK_SEARCH_URL`
- [x] DB 영향 여부 확인
  - 신규 schema 변경 없음
  - 기존 `books.cover_image_url` 컬럼 사용
  - 서버 시작 시 seed/dummy 책 중 `cover_image_url`이 비어 있는 행에 로컬 표지 URL이 채워질 수 있음

---

## 💬 리뷰 포인트
> 리뷰어가 집중해서 봐야 할 부분

- Kakao API 기반 표지 이미지 보강 로직
- 서버 시작 시 실행되는 `BookImagePredeployRunner`의 동작 범위
- `POST /api/books/images/enrich` API의 key 검증 방식
- `imageUrl`이 없는 경우와 이미지 로드 실패 시 fallback UI
- seed/dummy 책에 로컬 SVG 표지 URL을 주입하는 방식
