### PR TITLE
feat: 책 상세 화면 고도화(Closes #28)

### DIFF
--- a/backend/src/main/java/com/example/chaeklist/domain/book/dto/BookDetailResponse.java
+++ b/backend/src/main/java/com/example/chaeklist/domain/book/dto/BookDetailResponse.java
@@ -48,10 +48,23 @@ public record BookDetailResponse(
 ) {
 
 	public static BookDetailResponse from(Book book, List<Book> similarBooks) {
-		return from(book, similarBooks, false, false, false);
+		return from(book, similarBooks, null, List.of(), null, false, false, false);
 	}
 
 	public static BookDetailResponse from(Book book, List<Book> similarBooks, boolean saved, boolean read, boolean dismissed) {
+		return from(book, similarBooks, null, List.of(), null, saved, read, dismissed);
+	}
+
+	public static BookDetailResponse from(
+			Book book,
+			List<Book> similarBooks,
+			FilterReport filterReport,
+			List<RecommendationEvidence> recommendationEvidence,
+			ReadingGuide readingGuide,
+			boolean saved,
+			boolean read,
+			boolean dismissed
+	) {
 		return new BookDetailResponse(
 				book.id(),
 				book.title(),
@@ -66,85 +79,13 @@ public record BookDetailResponse(
 				"+" + book.growthRate() + "%",
 				book.keywords(),
 				similarBooks.stream().map(BookSummaryResponse::from).toList(),
-				createFilterReport(book),
-				createRecommendationEvidence(book),
-				createReadingGuide(book, similarBooks),
+				filterReport,
+				recommendationEvidence,
+				readingGuide,
 				saved,
 				read,
 				dismissed
 		);
-	}
-
-	private static FilterReport createFilterReport(Book book) {
-		return new FilterReport(
-				book.filterStatus(),
-				book.tag(),
-				"미분류".equals(book.category()) ? null : book.category(),
-				book.keywords()
-		);
-	}
-
-	private static List<RecommendationEvidence> createRecommendationEvidence(Book book) {
-		List<String> keywords = book.keywords();
-		java.util.ArrayList<RecommendationEvidence> evidence = new java.util.ArrayList<>();
-		if (!"미분류".equals(book.category())) {
-			evidence.add(new RecommendationEvidence(
-					"CATEGORY",
-					"관심 분야",
-					book.category() + " 분야 책을 찾는 사용자에게 맞는 후보입니다."
-			));
-		}
-		if (!keywords.isEmpty()) {
-			evidence.add(new RecommendationEvidence(
-					"KEYWORD",
-					"공통 키워드",
-					keywords.getFirst() + " 키워드를 중심으로 탐색할 수 있는 책입니다."
-			));
-		}
-		if (book.generalEligible()) {
-			evidence.add(new RecommendationEvidence(
-					"FILTER",
-					"교양 필터",
-					book.tag() + " 기준으로 상세 후보에 포함되었습니다."
-			));
-		}
-		return evidence.stream().limit(3).toList();
-	}
-
-	private static ReadingGuide createReadingGuide(Book book, List<Book> similarBooks) {
-		String fit = createFit(book);
-		String similarityNote = createSimilarityNote(book, similarBooks);
-		if (fit == null && similarityNote == null) {
-			return null;
-		}
-		return new ReadingGuide(fit, similarityNote);
-	}
-
-	private static String createFit(Book book) {
-		if (!"미분류".equals(book.category()) && !book.keywords().isEmpty()) {
-			return book.category() + " 분야에서 " + book.keywords().getFirst() + " 키워드를 기준으로 다음 읽을 책을 고르는 사용자에게 맞습니다.";
-		}
-		if (!"미분류".equals(book.category())) {
-			return book.category() + " 분야의 교양 도서를 찾는 사용자에게 맞습니다.";
-		}
-		return null;
-	}
-
-	private static String createSimilarityNote(Book book, List<Book> similarBooks) {
-		if (similarBooks.isEmpty()) {
-			return null;
-		}
-		Book similarBook = similarBooks.getFirst();
-		long sharedKeywordCount = similarBook.keywords().stream()
-				.filter(book.keywords()::contains)
-				.count();
-		if (sharedKeywordCount > 0) {
-			return "비슷한 책과 일부 키워드를 공유해 함께 비교해 볼 수 있습니다.";
-		}
-		if (book.category().equals(similarBook.category())) {
-			return "비슷한 책과 같은 분야에 속하지만 키워드 구성은 다를 수 있습니다.";
-		}
-		return null;
 	}
 
 	@Schema(description = "교양 필터 리포트")
@@ -164,7 +105,7 @@ public record BookDetailResponse(
 	public record RecommendationEvidence(
 			@Schema(description = "근거 유형", example = "CATEGORY")
 			String type,
-			@Schema(description = "근거 제목", example = "관심 분야")
+			@Schema(description = "근거 제목", example = "대표 분야")
 			String label,
 			@Schema(description = "근거 설명")
 			String description

--- a/backend/src/main/java/com/example/chaeklist/domain/book/dto/BookDetailResponse.java
+++ b/backend/src/main/java/com/example/chaeklist/domain/book/dto/BookDetailResponse.java
@@ -33,6 +33,12 @@ public record BookDetailResponse(
 		List<String> keywords,
 		@Schema(description = "비슷한 책 목록")
 		List<BookSummaryResponse> similarBooks,
+		@Schema(description = "교양 필터 리포트", nullable = true)
+		FilterReport filterReport,
+		@Schema(description = "추천 근거 목록")
+		List<RecommendationEvidence> recommendationEvidence,
+		@Schema(description = "읽을 책 결정 보조", nullable = true)
+		ReadingGuide readingGuide,
 		@Schema(description = "현재 사용자의 저장 여부", example = "true")
 		boolean saved,
 		@Schema(description = "현재 사용자의 읽음 여부", example = "false")
@@ -60,9 +66,117 @@ public record BookDetailResponse(
 				"+" + book.growthRate() + "%",
 				book.keywords(),
 				similarBooks.stream().map(BookSummaryResponse::from).toList(),
+				createFilterReport(book),
+				createRecommendationEvidence(book),
+				createReadingGuide(book, similarBooks),
 				saved,
 				read,
 				dismissed
 		);
+	}
+
+	private static FilterReport createFilterReport(Book book) {
+		return new FilterReport(
+				book.filterStatus(),
+				book.tag(),
+				"미분류".equals(book.category()) ? null : book.category(),
+				book.keywords()
+		);
+	}
+
+	private static List<RecommendationEvidence> createRecommendationEvidence(Book book) {
+		List<String> keywords = book.keywords();
+		java.util.ArrayList<RecommendationEvidence> evidence = new java.util.ArrayList<>();
+		if (!"미분류".equals(book.category())) {
+			evidence.add(new RecommendationEvidence(
+					"CATEGORY",
+					"관심 분야",
+					book.category() + " 분야 책을 찾는 사용자에게 맞는 후보입니다."
+			));
+		}
+		if (!keywords.isEmpty()) {
+			evidence.add(new RecommendationEvidence(
+					"KEYWORD",
+					"공통 키워드",
+					keywords.getFirst() + " 키워드를 중심으로 탐색할 수 있는 책입니다."
+			));
+		}
+		if (book.generalEligible()) {
+			evidence.add(new RecommendationEvidence(
+					"FILTER",
+					"교양 필터",
+					book.tag() + " 기준으로 상세 후보에 포함되었습니다."
+			));
+		}
+		return evidence.stream().limit(3).toList();
+	}
+
+	private static ReadingGuide createReadingGuide(Book book, List<Book> similarBooks) {
+		String fit = createFit(book);
+		String similarityNote = createSimilarityNote(book, similarBooks);
+		if (fit == null && similarityNote == null) {
+			return null;
+		}
+		return new ReadingGuide(fit, similarityNote);
+	}
+
+	private static String createFit(Book book) {
+		if (!"미분류".equals(book.category()) && !book.keywords().isEmpty()) {
+			return book.category() + " 분야에서 " + book.keywords().getFirst() + " 키워드를 기준으로 다음 읽을 책을 고르는 사용자에게 맞습니다.";
+		}
+		if (!"미분류".equals(book.category())) {
+			return book.category() + " 분야의 교양 도서를 찾는 사용자에게 맞습니다.";
+		}
+		return null;
+	}
+
+	private static String createSimilarityNote(Book book, List<Book> similarBooks) {
+		if (similarBooks.isEmpty()) {
+			return null;
+		}
+		Book similarBook = similarBooks.getFirst();
+		long sharedKeywordCount = similarBook.keywords().stream()
+				.filter(book.keywords()::contains)
+				.count();
+		if (sharedKeywordCount > 0) {
+			return "비슷한 책과 일부 키워드를 공유해 함께 비교해 볼 수 있습니다.";
+		}
+		if (book.category().equals(similarBook.category())) {
+			return "비슷한 책과 같은 분야에 속하지만 키워드 구성은 다를 수 있습니다.";
+		}
+		return null;
+	}
+
+	@Schema(description = "교양 필터 리포트")
+	public record FilterReport(
+			@Schema(description = "교양 필터 상태", example = "INCLUDED")
+			String status,
+			@Schema(description = "교양서로 노출된 이유", example = "교양 필터 통과")
+			String reason,
+			@Schema(description = "대표 카테고리", example = "인문", nullable = true)
+			String category,
+			@Schema(description = "주요 키워드", example = "[\"독서\", \"사유\"]")
+			List<String> keywords
+	) {
+	}
+
+	@Schema(description = "추천 근거")
+	public record RecommendationEvidence(
+			@Schema(description = "근거 유형", example = "CATEGORY")
+			String type,
+			@Schema(description = "근거 제목", example = "관심 분야")
+			String label,
+			@Schema(description = "근거 설명")
+			String description
+	) {
+	}
+
+	@Schema(description = "읽을 책 결정 보조")
+	public record ReadingGuide(
+			@Schema(description = "어떤 사용자에게 맞는지", nullable = true)
+			String fit,
+			@Schema(description = "비슷한 책과 비교할 때 참고할 점", nullable = true)
+			String similarityNote
+	) {
 	}
 }

--- a/backend/src/main/java/com/example/chaeklist/domain/book/entity/Book.java
+++ b/backend/src/main/java/com/example/chaeklist/domain/book/entity/Book.java
@@ -124,6 +124,18 @@ public class Book {
 		return generalEligible ? "교양 필터 통과" : filterStatus;
 	}
 
+	public boolean generalEligible() {
+		return generalEligible;
+	}
+
+	public String filterStatus() {
+		return filterStatus;
+	}
+
+	public String filterReason() {
+		return filterReason;
+	}
+
 	public String summary() {
 		return description == null ? "" : description;
 	}

--- a/backend/src/main/java/com/example/chaeklist/domain/book/service/BookService.java
+++ b/backend/src/main/java/com/example/chaeklist/domain/book/service/BookService.java
@@ -1,5 +1,6 @@
 package com.example.chaeklist.domain.book.service;
 
+import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
@@ -7,6 +8,9 @@ import java.util.Optional;
 import java.util.Set;
 
 import com.example.chaeklist.domain.book.dto.BookDetailResponse;
+import com.example.chaeklist.domain.book.dto.BookDetailResponse.FilterReport;
+import com.example.chaeklist.domain.book.dto.BookDetailResponse.ReadingGuide;
+import com.example.chaeklist.domain.book.dto.BookDetailResponse.RecommendationEvidence;
 import com.example.chaeklist.domain.book.dto.BookSummaryResponse;
 import com.example.chaeklist.domain.book.dto.CategoryRankingResponse;
 import com.example.chaeklist.domain.book.dto.HomeResponse;
@@ -100,7 +104,7 @@ public class BookService {
 		Book book = bookRepository.findByIdAndGeneralEligibleTrue(id)
 				.orElseThrow(() -> new BookNotFoundException("Book not found."));
 		List<Book> similarBooks = findSimilarBooks(book);
-		return BookDetailResponse.from(book, similarBooks);
+		return createBookDetailResponse(book, similarBooks, false, false, false);
 	}
 
 	public BookDetailResponse getBookDetail(String bookId, AuthenticatedUser user) {
@@ -108,7 +112,98 @@ public class BookService {
 		Book book = bookRepository.findByIdAndGeneralEligibleTrue(id)
 				.orElseThrow(() -> new BookNotFoundException("Book not found."));
 		List<Book> similarBooks = findSimilarBooks(book);
-		return BookDetailResponse.from(book, similarBooks, isSaved(user.id(), id), isRead(user.id(), id), isDismissed(user.id(), id));
+		return createBookDetailResponse(book, similarBooks, isSaved(user.id(), id), isRead(user.id(), id), isDismissed(user.id(), id));
+	}
+
+	private BookDetailResponse createBookDetailResponse(
+			Book book,
+			List<Book> similarBooks,
+			boolean saved,
+			boolean read,
+			boolean dismissed
+	) {
+		return BookDetailResponse.from(
+				book,
+				similarBooks,
+				createFilterReport(book),
+				createRecommendationEvidence(book),
+				createReadingGuide(book, similarBooks),
+				saved,
+				read,
+				dismissed
+		);
+	}
+
+	private FilterReport createFilterReport(Book book) {
+		return new FilterReport(
+				book.filterStatus(),
+				book.tag(),
+				"미분류".equals(book.category()) ? null : book.category(),
+				book.keywords()
+		);
+	}
+
+	private List<RecommendationEvidence> createRecommendationEvidence(Book book) {
+		List<String> keywords = book.keywords();
+		ArrayList<RecommendationEvidence> evidence = new ArrayList<>();
+		if (!"미분류".equals(book.category())) {
+			evidence.add(new RecommendationEvidence(
+					"CATEGORY",
+					"대표 분야",
+					book.category() + " 분야의 교양 도서를 찾을 때 비교할 수 있는 후보입니다."
+			));
+		}
+		if (!keywords.isEmpty()) {
+			evidence.add(new RecommendationEvidence(
+					"KEYWORD",
+					"공통 키워드",
+					keywords.getFirst() + " 키워드를 중심으로 탐색할 수 있는 책입니다."
+			));
+		}
+		if (book.generalEligible()) {
+			evidence.add(new RecommendationEvidence(
+					"FILTER",
+					"교양 필터",
+					book.tag() + " 기준으로 상세 후보에 포함되었습니다."
+			));
+		}
+		return evidence.stream().limit(3).toList();
+	}
+
+	private ReadingGuide createReadingGuide(Book book, List<Book> similarBooks) {
+		String fit = createFit(book);
+		String similarityNote = createSimilarityNote(book, similarBooks);
+		if (fit == null && similarityNote == null) {
+			return null;
+		}
+		return new ReadingGuide(fit, similarityNote);
+	}
+
+	private String createFit(Book book) {
+		if (!"미분류".equals(book.category()) && !book.keywords().isEmpty()) {
+			return book.category() + " 분야에서 " + book.keywords().getFirst() + " 키워드를 기준으로 다음 읽을 책을 고르는 사용자에게 맞습니다.";
+		}
+		if (!"미분류".equals(book.category())) {
+			return book.category() + " 분야의 교양 도서를 찾는 사용자에게 맞습니다.";
+		}
+		return null;
+	}
+
+	private String createSimilarityNote(Book book, List<Book> similarBooks) {
+		if (similarBooks.isEmpty()) {
+			return null;
+		}
+		Book similarBook = similarBooks.getFirst();
+		long sharedKeywordCount = similarBook.keywords().stream()
+				.filter(book.keywords()::contains)
+				.count();
+		if (sharedKeywordCount > 0) {
+			return "비슷한 책과 일부 키워드를 공유해 함께 비교해 볼 수 있습니다.";
+		}
+		if (book.category().equals(similarBook.category())) {
+			return "비슷한 책과 같은 분야에 속하지만 키워드 구성은 다를 수 있습니다.";
+		}
+		return null;
 	}
 
 	private boolean isSaved(long userId, long bookId) {

--- a/backend/src/test/java/com/example/chaeklist/BookControllerTest.java
+++ b/backend/src/test/java/com/example/chaeklist/BookControllerTest.java
@@ -174,6 +174,9 @@ class BookControllerTest {
 				.andExpect(jsonPath("$.filterReport.keywords[0]", is("투자")))
 				.andExpect(jsonPath("$.recommendationEvidence", hasSize(3)))
 				.andExpect(jsonPath("$.recommendationEvidence[0].type", is("CATEGORY")))
+				.andExpect(jsonPath("$.recommendationEvidence[0].label", is("대표 분야")))
+				.andExpect(jsonPath("$.recommendationEvidence[0].description",
+						is("경제 분야의 교양 도서를 찾을 때 비교할 수 있는 후보입니다.")))
 				.andExpect(jsonPath("$.recommendationEvidence[1].type", is("KEYWORD")))
 				.andExpect(jsonPath("$.recommendationEvidence[2].type", is("FILTER")))
 				.andExpect(jsonPath("$.readingGuide.fit",
@@ -184,6 +187,25 @@ class BookControllerTest {
 				.andExpect(jsonPath("$.similarBooks[0].id", is("302")))
 				.andExpect(jsonPath("$.similarBooks[?(@.id == '301')]", hasSize(0)))
 				.andExpect(jsonPath("$.similarBooks[?(@.id == '306')]", hasSize(0)));
+	}
+
+	@Test
+	@Transactional
+	void returnsBookDetailWithEmptyOptionalGuideData() throws Exception {
+		insertBook(312, "분류 없는 책", true);
+
+		mockMvc.perform(get("/api/books/{bookId}", "312"))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.id", is("312")))
+				.andExpect(jsonPath("$.category", is("미분류")))
+				.andExpect(jsonPath("$.filterReport.status", is("INCLUDED")))
+				.andExpect(jsonPath("$.filterReport.reason", is("교양 필터 통과")))
+				.andExpect(jsonPath("$.filterReport.category", nullValue()))
+				.andExpect(jsonPath("$.filterReport.keywords", hasSize(0)))
+				.andExpect(jsonPath("$.recommendationEvidence", hasSize(1)))
+				.andExpect(jsonPath("$.recommendationEvidence[0].type", is("FILTER")))
+				.andExpect(jsonPath("$.readingGuide", nullValue()))
+				.andExpect(jsonPath("$.similarBooks", hasSize(0)));
 	}
 
 	@Test

--- a/backend/src/test/java/com/example/chaeklist/BookControllerTest.java
+++ b/backend/src/test/java/com/example/chaeklist/BookControllerTest.java
@@ -168,6 +168,18 @@ class BookControllerTest {
 				.andExpect(jsonPath("$.dismissed", is(false)))
 				.andExpect(jsonPath("$.keywords", hasSize(1)))
 				.andExpect(jsonPath("$.keywords[0]", is("투자")))
+				.andExpect(jsonPath("$.filterReport.status", is("INCLUDED")))
+				.andExpect(jsonPath("$.filterReport.reason", is("교양 필터 통과")))
+				.andExpect(jsonPath("$.filterReport.category", is("경제")))
+				.andExpect(jsonPath("$.filterReport.keywords[0]", is("투자")))
+				.andExpect(jsonPath("$.recommendationEvidence", hasSize(3)))
+				.andExpect(jsonPath("$.recommendationEvidence[0].type", is("CATEGORY")))
+				.andExpect(jsonPath("$.recommendationEvidence[1].type", is("KEYWORD")))
+				.andExpect(jsonPath("$.recommendationEvidence[2].type", is("FILTER")))
+				.andExpect(jsonPath("$.readingGuide.fit",
+						is("경제 분야에서 투자 키워드를 기준으로 다음 읽을 책을 고르는 사용자에게 맞습니다.")))
+				.andExpect(jsonPath("$.readingGuide.similarityNote",
+						is("비슷한 책과 일부 키워드를 공유해 함께 비교해 볼 수 있습니다.")))
 				.andExpect(jsonPath("$.similarBooks", hasSize(3)))
 				.andExpect(jsonPath("$.similarBooks[0].id", is("302")))
 				.andExpect(jsonPath("$.similarBooks[?(@.id == '301')]", hasSize(0)))

--- a/frontend/src/pages/BookDetailPage.jsx
+++ b/frontend/src/pages/BookDetailPage.jsx
@@ -12,6 +12,12 @@ const coverPalette = {
   자기계발: "bg-[#F59E0B]",
 };
 
+const evidenceStyles = {
+  CATEGORY: "border-[#4CAF50]/30 bg-[#4CAF50]/10 text-[#2f6f34]",
+  KEYWORD: "border-[#F59E0B]/30 bg-[#F59E0B]/10 text-[#9a6207]",
+  FILTER: "border-[#1E2A38]/20 bg-[#1E2A38]/5 text-[#1E2A38]",
+};
+
 function withDisplayDefaults(book) {
   if (!book) {
     return null;
@@ -24,10 +30,120 @@ function withDisplayDefaults(book) {
     keywords: book.keywords ?? [],
     reason: book.reason ?? book.recommendationReason,
     similarBooks: (book.similarBooks ?? []).map(withDisplayDefaults),
+    filterReport: book.filterReport
+      ? {
+          ...book.filterReport,
+          keywords: book.filterReport.keywords ?? [],
+        }
+      : null,
+    recommendationEvidence: book.recommendationEvidence ?? [],
+    readingGuide: book.readingGuide ?? null,
     saved: Boolean(book.saved),
     read: Boolean(book.read),
     dismissed: Boolean(book.dismissed),
   };
+}
+
+function hasFilterReport(report) {
+  return Boolean(report?.status || report?.reason || report?.category || report?.keywords?.length);
+}
+
+function hasReadingGuide(readingGuide) {
+  return Boolean(readingGuide?.fit || readingGuide?.similarityNote);
+}
+
+function FilterReportSection({ report }) {
+  if (!hasFilterReport(report)) {
+    return null;
+  }
+
+  const fields = [
+    ["상태", report.status],
+    ["대표 분야", report.category],
+    ["판단 근거", report.reason],
+  ].filter(([, value]) => value);
+
+  return (
+    <section className="rounded-lg border border-[#E5E7EB] bg-white p-5 shadow-sm">
+      <div>
+        <p className="text-sm font-semibold text-[#4CAF50]">교양 필터 리포트</p>
+        <h2 className="mt-1 text-xl font-bold text-[#1E2A38]">이 책이 상세 후보에 오른 이유</h2>
+      </div>
+      <div className="mt-5 grid grid-cols-1 gap-3 sm:grid-cols-3">
+        {fields.map(([label, value]) => (
+          <div className="rounded-md border border-[#E5E7EB] p-4" key={label}>
+            <p className="text-xs font-semibold text-[#6B7280]">{label}</p>
+            <p className="mt-2 text-sm font-bold text-[#1E2A38]">{value}</p>
+          </div>
+        ))}
+      </div>
+      {report.keywords?.length ? (
+        <div className="mt-4 flex flex-wrap gap-2">
+          {report.keywords.slice(0, 6).map((keyword) => (
+            <span className="rounded-full border border-[#E5E7EB] px-3 py-2 text-sm text-[#6B7280]" key={keyword}>
+              {keyword}
+            </span>
+          ))}
+        </div>
+      ) : null}
+    </section>
+  );
+}
+
+function RecommendationEvidenceSection({ evidence }) {
+  const visibleEvidence = (evidence ?? []).filter((item) => item?.label || item?.description).slice(0, 3);
+  if (!visibleEvidence.length) {
+    return null;
+  }
+
+  return (
+    <section className="rounded-lg border border-[#E5E7EB] bg-white p-5 shadow-sm">
+      <div>
+        <p className="text-sm font-semibold text-[#4CAF50]">추천 근거</p>
+        <h2 className="mt-1 text-xl font-bold text-[#1E2A38]">어떤 기준으로 볼 만한 책인가</h2>
+      </div>
+      <div className="mt-5 grid grid-cols-1 gap-3 md:grid-cols-3">
+        {visibleEvidence.map((item, index) => (
+          <article
+            className={`rounded-md border p-4 ${evidenceStyles[item.type] ?? "border-[#E5E7EB] bg-white text-[#1E2A38]"}`}
+            key={`${item.type ?? "EVIDENCE"}-${index}`}
+          >
+            {item.label ? <h3 className="text-sm font-bold">{item.label}</h3> : null}
+            {item.description ? <p className="mt-2 text-sm leading-6 text-[#6B7280]">{item.description}</p> : null}
+          </article>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function ReadingGuideSection({ readingGuide }) {
+  if (!hasReadingGuide(readingGuide)) {
+    return null;
+  }
+
+  return (
+    <section className="rounded-lg border border-[#E5E7EB] bg-white p-5 shadow-sm">
+      <div>
+        <p className="text-sm font-semibold text-[#4CAF50]">읽을 책 결정 보조</p>
+        <h2 className="mt-1 text-xl font-bold text-[#1E2A38]">고르기 전에 볼 포인트</h2>
+      </div>
+      <div className="mt-5 grid grid-cols-1 gap-3 md:grid-cols-2">
+        {readingGuide.fit ? (
+          <div className="rounded-md border border-[#E5E7EB] p-4">
+            <p className="text-xs font-semibold text-[#6B7280]">맞는 사용자</p>
+            <p className="mt-2 text-sm leading-6 text-[#111827]">{readingGuide.fit}</p>
+          </div>
+        ) : null}
+        {readingGuide.similarityNote ? (
+          <div className="rounded-md border border-[#E5E7EB] p-4">
+            <p className="text-xs font-semibold text-[#6B7280]">비슷한 책과 비교</p>
+            <p className="mt-2 text-sm leading-6 text-[#111827]">{readingGuide.similarityNote}</p>
+          </div>
+        ) : null}
+      </div>
+    </section>
+  );
 }
 
 export default function BookDetailPage() {
@@ -294,6 +410,14 @@ export default function BookDetailPage() {
           ) : null}
         </div>
       </div>
+
+      {hasFilterReport(book.filterReport) || book.recommendationEvidence?.length || hasReadingGuide(book.readingGuide) ? (
+        <div className="mt-6 grid grid-cols-1 gap-4">
+          <FilterReportSection report={book.filterReport} />
+          <RecommendationEvidenceSection evidence={book.recommendationEvidence} />
+          <ReadingGuideSection readingGuide={book.readingGuide} />
+        </div>
+      ) : null}
 
       {similarBooks.length ? (
         <section className="mt-6">

--- a/frontend/src/pages/HomePage.jsx
+++ b/frontend/src/pages/HomePage.jsx
@@ -188,7 +188,12 @@ export default function HomePage() {
 
         <aside className="rounded-lg border border-[#E5E7EB] bg-white p-5 shadow-sm">
           <p className="text-sm font-semibold text-[#1E2A38]">카테고리별 랭킹</p>
-          <h2 className="mt-2 text-xl font-bold text-[#1E2A38]">교양 독서 기준 TOP 리스트</h2>
+          <div className="mt-2 flex items-center justify-between gap-3">
+            <h2 className="text-xl font-bold text-[#1E2A38]">교양 독서 기준 TOP 리스트</h2>
+            <Link className="shrink-0 text-xs font-semibold text-[#6B7280] hover:text-[#1E2A38]" to="/categories">
+              더보기
+            </Link>
+          </div>
           <div className="mt-5 space-y-4">
             {isLoading ? (
               <p className="text-sm text-[#6B7280]">카테고리 랭킹을 불러오는 중입니다.</p>
@@ -196,12 +201,7 @@ export default function HomePage() {
               home.categoryRankings.length ? (
                 home.categoryRankings.map((group) => (
                   <div className="border-b border-[#E5E7EB] pb-4 last:border-b-0 last:pb-0" key={group.category}>
-                    <div className="flex items-center justify-between gap-3">
-                      <p className="font-semibold text-[#1E2A38]">{group.category}</p>
-                      <Link className="shrink-0 text-xs font-semibold text-[#6B7280] hover:text-[#1E2A38]" to="/categories">
-                        더보기
-                      </Link>
-                    </div>
+                    <p className="font-semibold text-[#1E2A38]">{group.category}</p>
                     <p className="mt-2 line-clamp-1 text-sm text-[#6B7280]">{group.books[0]?.title ?? "준비 중"}</p>
                   </div>
                 ))


### PR DESCRIPTION
## 📌 개요
> 어떤 변경 사항인지

- 책 상세 화면에서 ChaekList의 차별점인 교양 필터링/추천 근거를 더 명확히 보여주도록 API 응답과 UI를 확장했습니다.
- 홈의 `교양 독서 기준 TOP 리스트`에서 카테고리 탭 이동 링크가 반복되던 부분을 정리했습니다.

---

## 🔗 관련 이슈
- Closes #28

---

## ✨ 작업 내용
> 주요 변경 사항

### 🔹 Backend
- 책 상세 API 응답에 교양 독서 판단용 필드 추가
  - `filterReport`
  - `recommendationEvidence`
  - `readingGuide`
- `BookService`에서 기존 데이터 기반 설명 생성
  - 교양 필터 상태/사유
  - 대표 카테고리
  - 주요 키워드
  - 비슷한 책과의 비교 포인트
- `Book` 엔티티에 필터 관련 읽기 접근자 추가
  - `generalEligible()`
  - `filterStatus()`
  - `filterReason()`
- 개인화 데이터 없이 “관심 분야”처럼 보이는 문구를 제거하고 `대표 분야` 기준 문구로 정리
- 책 상세 API 테스트 보강
  - 교양 필터 리포트 응답 검증
  - 추천 근거 응답 검증
  - 카테고리/키워드/비슷한 책이 없는 경우 검증

### 🔹 Frontend
- 책 상세 화면에 backend 신규 응답 필드 표시
  - 교양 필터 리포트
  - 추천 근거 카드
  - 읽을 책 결정 보조
- 신규 응답 필드가 없을 때는 기존 화면이 유지되도록 조건부 렌더링 처리
- 홈 `교양 독서 기준 TOP 리스트`의 카테고리별 반복 `더보기` 링크 제거
- `/categories` 이동은 섹션 제목 옆 단일 `더보기` 링크로 정리
- `더보기` 링크 위치를 제목 중앙 높이에 맞게 조정

---

## 🧪 테스트 결과
- [x] 로컬 테스트 완료
- [x] API 정상 동작 확인
- [x] 에러 케이스 확인

실행한 검증:
- `backend`: `.\gradlew.bat test` 통과
- `frontend`: `npm run build` 통과

---

## 📸 스크린샷 (선택)
> UI 변경 시 첨부

- 책 상세 화면 신규 섹션과 홈 `더보기` 위치는 PR 코멘트에 필요 시 첨부 예정

---

## ⚠️ 주의사항
- 새 DB 컬럼이나 schema 변경은 없습니다.
- 신규 설명 문구는 현재 보유한 카테고리/키워드/필터 상태/비슷한 책 데이터만 사용합니다.
- 난이도, 독서 분위기, 제외 키워드 부재처럼 데이터 출처가 없는 내용은 단정하지 않았습니다.
- `filter_reason` 원본 품질이 낮으면 교양 필터 리포트의 설득력도 낮을 수 있습니다.

---

## 🚀 배포 전 체크리스트
- [x] 빌드 성공 (`npm run build`)
- [x] Backend 테스트 성공 (`.\gradlew.bat test`)
- [ ] Backend 전체 빌드 확인 (`.\gradlew.bat build`)
- [x] 환경변수 설정 영향 없음
- [x] DB 영향 없음

---

## 💬 리뷰 포인트
> 리뷰어가 집중해서 봐야 할 부분

- 책 상세 API의 신규 응답 구조가 frontend 사용에 적절한지
- `filterReport`, `recommendationEvidence`, `readingGuide` 문구가 과장되거나 개인화처럼 오해되지 않는지
- 데이터가 없는 책에서 신규 섹션이 자연스럽게 숨겨지는지
- 홈 `교양 독서 기준 TOP 리스트`의 `더보기` 위치와 카테고리 탭 이동 동선이 자연스러운지
