### PR TITLE
feat: 온보딩 및 마이페이지 검색 기반 책 추가(Closes #30)

### DIFF
--- a/backend/src/main/java/com/example/chaeklist/domain/book/controller/BookController.java
+++ b/backend/src/main/java/com/example/chaeklist/domain/book/controller/BookController.java
@@ -101,6 +101,17 @@ public class BookController {
 		return bookService.getCategories();
 	}
 
+	@GetMapping("/api/books/search")
+	@Operation(summary = "책 검색", description = "교양 필터를 통과한 책을 제목 또는 저자로 검색합니다.")
+	@ApiResponse(responseCode = "200", description = "책 검색 성공")
+	@ApiResponse(responseCode = "400", description = "검색어가 비어 있거나 너무 짧음")
+	public List<BookSummaryResponse> searchBooks(
+			@Parameter(description = "검색어. 최소 2자", example = "투자") @RequestParam String query,
+			@Parameter(description = "반환 개수. 최대 20", example = "10") @RequestParam(defaultValue = "10") int limit
+	) {
+		return bookService.searchBooks(query, limit);
+	}
+
 	@GetMapping("/api/books/categories/{category}/rankings")
 	@Operation(summary = "카테고리별 랭킹 조회", description = "특정 카테고리의 랭킹 목록을 반환합니다.")
 	@ApiResponse(responseCode = "200", description = "카테고리 랭킹 조회 성공")

--- a/backend/src/main/java/com/example/chaeklist/domain/book/repository/BookRepository.java
+++ b/backend/src/main/java/com/example/chaeklist/domain/book/repository/BookRepository.java
@@ -6,6 +6,8 @@ import java.util.Optional;
 import com.example.chaeklist.domain.book.entity.Book;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface BookRepository extends JpaRepository<Book, Long> {
 
@@ -16,4 +18,15 @@ public interface BookRepository extends JpaRepository<Book, Long> {
 	List<Book> findByCategoriesNameAndGeneralEligibleTrue(String category, Pageable pageable);
 
 	List<Book> findByCategoriesNameAndGeneralEligibleTrueAndIdNot(String category, Long id, Pageable pageable);
+
+	@Query("""
+			SELECT b
+			FROM Book b
+			WHERE b.generalEligible = TRUE
+				AND (
+					LOWER(b.title) LIKE LOWER(CONCAT('%', :query, '%'))
+					OR LOWER(b.author) LIKE LOWER(CONCAT('%', :query, '%'))
+				)
+			""")
+	List<Book> searchGeneralEligibleByTitleOrAuthor(@Param("query") String query, Pageable pageable);
 }

--- a/backend/src/main/java/com/example/chaeklist/domain/book/service/BookService.java
+++ b/backend/src/main/java/com/example/chaeklist/domain/book/service/BookService.java
@@ -33,6 +33,9 @@ public class BookService {
 	private static final int SIMILAR_BOOK_LIMIT = 3;
 	private static final int SIMILAR_BOOK_CANDIDATE_LIMIT = 50;
 	private static final int PERSONAL_RECOMMENDATION_CANDIDATE_LIMIT = 50;
+	private static final int SEARCH_DEFAULT_LIMIT = 10;
+	private static final int SEARCH_MAX_LIMIT = 20;
+	private static final int SEARCH_MIN_QUERY_LENGTH = 2;
 	private static final String FALLBACK_RECOMMENDATION_REASON = "랭킹 지표와 교양 필터링 기준을 반영한 책입니다.";
 
 	private final BookRepository bookRepository;
@@ -88,6 +91,13 @@ public class BookService {
 	public List<String> getCategories() {
 		return categoryRepository.findByActiveTrueOrderByDisplayOrderAsc().stream()
 				.map(category -> category.name())
+				.toList();
+	}
+
+	public List<BookSummaryResponse> searchBooks(String query, int limit) {
+		String normalizedQuery = normalizeSearchQuery(query);
+		return bookRepository.searchGeneralEligibleByTitleOrAuthor(normalizedQuery, pageById(normalizeSearchLimit(limit))).stream()
+				.map(BookSummaryResponse::from)
 				.toList();
 	}
 
@@ -510,6 +520,20 @@ public class BookService {
 			return 10;
 		}
 		return Math.min(limit, 50);
+	}
+
+	private int normalizeSearchLimit(int limit) {
+		if (limit <= 0) {
+			return SEARCH_DEFAULT_LIMIT;
+		}
+		return Math.min(limit, SEARCH_MAX_LIMIT);
+	}
+
+	private String normalizeSearchQuery(String query) {
+		if (query == null || query.trim().length() < SEARCH_MIN_QUERY_LENGTH) {
+			throw new BookRequestException("Search query must be at least 2 characters.");
+		}
+		return query.trim();
 	}
 
 	private void validateCategory(String category, boolean allowAll) {

--- a/backend/src/test/java/com/example/chaeklist/BookControllerTest.java
+++ b/backend/src/test/java/com/example/chaeklist/BookControllerTest.java
@@ -123,6 +123,62 @@ class BookControllerTest {
 	}
 
 	@Test
+	@Transactional
+	void searchesBooksByTitle() throws Exception {
+		insertCategory(701, "경제");
+		insertBook(711, "조용한 투자 습관", true);
+		insertBook(712, "투자 제외 도서", false);
+		insertBook(713, "느리게 읽는 힘", true);
+		insertBookCategory(711, 701);
+		insertBookCategory(712, 701);
+		insertBookCategory(713, 701);
+
+		mockMvc.perform(get("/api/books/search")
+						.param("query", "투자")
+						.param("limit", "10"))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$", hasSize(1)))
+				.andExpect(jsonPath("$[0].id", is("711")))
+				.andExpect(jsonPath("$[0].title", is("조용한 투자 습관")))
+				.andExpect(jsonPath("$[0].category", is("경제")))
+				.andExpect(jsonPath("$[0].recommendationReason",
+						is("최근 경제 분야에서 교양 필터를 통과해 추천됩니다.")));
+	}
+
+	@Test
+	@Transactional
+	void searchesBooksByAuthor() throws Exception {
+		insertBookWithAuthor(721, "철학 입문", "김투자", true);
+		insertBookWithAuthor(722, "경제 입문", "다른 저자", true);
+
+		mockMvc.perform(get("/api/books/search")
+						.param("query", "김투자"))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$", hasSize(1)))
+				.andExpect(jsonPath("$[0].id", is("721")))
+				.andExpect(jsonPath("$[0].author", is("김투자")));
+	}
+
+	@Test
+	@Transactional
+	void returnsEmptySearchResult() throws Exception {
+		insertBook(731, "읽을 만한 책", true);
+
+		mockMvc.perform(get("/api/books/search")
+						.param("query", "없는검색어"))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$", hasSize(0)));
+	}
+
+	@Test
+	void rejectsShortSearchQuery() throws Exception {
+		mockMvc.perform(get("/api/books/search")
+						.param("query", "투"))
+				.andExpect(status().isBadRequest())
+				.andExpect(jsonPath("$.message", is("Search query must be at least 2 characters.")));
+	}
+
+	@Test
 	void rejectsUnknownCategoryRankings() throws Exception {
 		mockMvc.perform(get("/api/books/categories/{category}/rankings", "경제")
 						.param("period", "weekly"))
@@ -506,6 +562,15 @@ class BookControllerTest {
 				)
 				VALUES (?, ?, '테스트 저자', '상세 설명', ?, 'INCLUDED', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
 				""", id, title, generalEligible);
+	}
+
+	private void insertBookWithAuthor(long id, String title, String author, boolean generalEligible) {
+		jdbcTemplate.update("""
+				INSERT INTO books (
+					id, title, author, description, is_general_eligible, filter_status, created_at, updated_at
+				)
+				VALUES (?, ?, ?, '상세 설명', ?, 'INCLUDED', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+				""", id, title, author, generalEligible);
 	}
 
 	private void insertBookCategory(long bookId, long categoryId) {

--- a/frontend/src/components/BookSearchPanel.jsx
+++ b/frontend/src/components/BookSearchPanel.jsx
@@ -1,0 +1,161 @@
+import { useState } from "react";
+
+function normalizeSearchBook(book) {
+  return {
+    id: book.id ?? book.bookId,
+    title: book.title ?? "제목 없음",
+    author: book.author ?? "저자 미상",
+    category: book.category ?? book.categoryName ?? "교양",
+    tag: book.tag ?? "교양 필터 통과",
+    recommendationReason: book.recommendationReason ?? book.reason ?? "교양 독서 후보로 확인할 수 있는 책입니다.",
+    imageUrl: book.imageUrl ?? book.coverImageUrl,
+    views: book.views ?? "0",
+    saves: book.saves ?? 0,
+    growthRate: book.growthRate,
+  };
+}
+
+export default function BookSearchPanel({
+  actionLabel,
+  disabledIds = [],
+  emptyMessage = "검색 결과가 없습니다.",
+  onResults,
+  onSelect,
+  selectedIds = [],
+  selectedLabel = "선택됨",
+  title = "책 검색",
+}) {
+  const [query, setQuery] = useState("");
+  const [results, setResults] = useState([]);
+  const [status, setStatus] = useState("idle");
+  const [message, setMessage] = useState("");
+  const [pendingBookId, setPendingBookId] = useState("");
+
+  const disabledIdSet = new Set(disabledIds.map(String));
+  const selectedIdSet = new Set(selectedIds.map(String));
+
+  async function searchBooks() {
+    const trimmedQuery = query.trim();
+    if (trimmedQuery.length < 2) {
+      setResults([]);
+      setStatus("idle");
+      setMessage("검색어를 2자 이상 입력해 주세요.");
+      return;
+    }
+
+    setStatus("loading");
+    setMessage("");
+
+    try {
+      const response = await fetch(`/api/books/search?query=${encodeURIComponent(trimmedQuery)}&limit=10`);
+
+      if (!response.ok) {
+        const data = await response.json().catch(() => ({}));
+        throw new Error(data.message ?? "책 검색에 실패했습니다.");
+      }
+
+      const data = await response.json();
+      const nextResults = data.map(normalizeSearchBook).filter((book) => book.id);
+      setResults(nextResults);
+      onResults?.(nextResults);
+      setMessage(nextResults.length === 0 ? emptyMessage : "");
+      setStatus("ready");
+    } catch (error) {
+      setResults([]);
+      if (error instanceof TypeError) {
+        setMessage("검색 API에 연결하지 못했습니다. backend 서버 실행 상태를 확인해 주세요.");
+      } else {
+        setMessage(error instanceof Error ? error.message : "알 수 없는 오류가 발생했습니다.");
+      }
+      setStatus("error");
+    }
+  }
+
+  function handleSearchKeyDown(event) {
+    if (event.key === "Enter") {
+      event.preventDefault();
+      searchBooks();
+    }
+  }
+
+  async function selectBook(book) {
+    if (disabledIdSet.has(String(book.id))) {
+      return;
+    }
+
+    setPendingBookId(book.id);
+    setMessage("");
+
+    try {
+      await onSelect(book);
+      setMessage(`${book.title}을 반영했습니다.`);
+    } catch (error) {
+      setMessage(error instanceof Error ? error.message : "책을 반영하지 못했습니다.");
+    } finally {
+      setPendingBookId("");
+    }
+  }
+
+  return (
+    <div className="mt-5 rounded-lg border border-[#E5E7EB] bg-[#F9FAFB] p-4">
+      <div className="flex flex-col gap-3 sm:flex-row">
+        <label className="min-w-0 flex-1">
+          <span className="sr-only">{title}</span>
+          <input
+            className="w-full rounded-md border border-[#E5E7EB] bg-white px-4 py-3 text-sm text-[#1E2A38] outline-none transition placeholder:text-[#9CA3AF] focus:border-[#1E2A38]"
+            onChange={(event) => setQuery(event.target.value)}
+            onKeyDown={handleSearchKeyDown}
+            placeholder="제목 또는 저자 검색"
+            type="search"
+            value={query}
+          />
+        </label>
+        <button
+          className="rounded-md bg-[#1E2A38] px-4 py-3 text-sm font-semibold text-white transition hover:bg-[#27384a] disabled:cursor-not-allowed disabled:bg-[#9CA3AF]"
+          disabled={status === "loading"}
+          onClick={searchBooks}
+          type="button"
+        >
+          {status === "loading" ? "검색 중" : "검색"}
+        </button>
+      </div>
+
+      {message ? <p className={`mt-3 text-sm ${status === "error" ? "text-red-600" : "text-[#6B7280]"}`}>{message}</p> : null}
+
+      {results.length > 0 ? (
+        <div className="mt-4 divide-y divide-[#E5E7EB] rounded-md border border-[#E5E7EB] bg-white">
+          {results.map((book) => {
+            const isSelected = selectedIdSet.has(String(book.id));
+            const isDisabled = disabledIdSet.has(String(book.id));
+            const isPending = pendingBookId === book.id;
+
+            return (
+              <div className="flex flex-col gap-3 p-4 md:flex-row md:items-center md:justify-between" key={book.id}>
+                <div className="min-w-0">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <p className="font-bold text-[#1E2A38]">{book.title}</p>
+                    <span className="rounded-full border border-[#E5E7EB] px-2 py-1 text-xs text-[#6B7280]">{book.category}</span>
+                  </div>
+                  <p className="mt-1 text-sm text-[#6B7280]">{book.author}</p>
+                  <p className="mt-2 line-clamp-2 text-sm leading-6 text-[#6B7280]">{book.recommendationReason}</p>
+                </div>
+                <button
+                  className={`shrink-0 rounded-md px-3 py-2 text-sm font-semibold transition ${
+                    isSelected || isDisabled
+                      ? "bg-[#E5E7EB] text-[#6B7280]"
+                      : "bg-[#4CAF50] text-white hover:bg-[#3f9744]"
+                  } disabled:cursor-not-allowed disabled:opacity-70`}
+                  disabled={isSelected || isDisabled || Boolean(pendingBookId)}
+                  onClick={() => selectBook(book)}
+                  type="button"
+                >
+                  {isPending ? "반영 중" : isSelected || isDisabled ? selectedLabel : actionLabel}
+                </button>
+              </div>
+            );
+          })}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/frontend/src/pages/MyPage.jsx
+++ b/frontend/src/pages/MyPage.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
 import BookCard from "../components/BookCard";
+import BookSearchPanel from "../components/BookSearchPanel";
 import { useAuth } from "../App";
 
 function formatDate(value) {
@@ -45,6 +46,14 @@ function EmptyState({ message, actionLabel, to }) {
       </Link>
     </div>
   );
+}
+
+function toMyPageBook(book) {
+  return {
+    ...book,
+    reason: book.reason ?? book.recommendationReason,
+    recommendationReason: book.recommendationReason ?? book.reason,
+  };
 }
 
 export default function MyPage() {
@@ -107,6 +116,47 @@ export default function MyPage() {
   const readBooks = myPage?.readBooks ?? [];
   const savedBooks = myPage?.savedBooks ?? [];
   const recommendationHistory = myPage?.recommendationHistory ?? [];
+
+  async function addBookInteraction(book, type) {
+    const response = await fetch(`/api/me/books/${book.id}/interactions`, {
+      body: JSON.stringify({ type }),
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        "Content-Type": "application/json",
+      },
+      method: "POST",
+    });
+
+    if (response.status === 401) {
+      logout();
+      throw new Error("로그인이 만료되었습니다. 다시 로그인해 주세요.");
+    }
+
+    if (!response.ok) {
+      throw new Error("책 상태를 저장하지 못했습니다.");
+    }
+
+    const normalizedBook = toMyPageBook(book);
+    setMyPage((current) => {
+      if (!current) {
+        return current;
+      }
+
+      if (type === "READ") {
+        const hasReadBook = (current.readBooks ?? []).some((item) => String(item.id) === String(book.id));
+        return {
+          ...current,
+          readBooks: hasReadBook ? current.readBooks : [normalizedBook, ...(current.readBooks ?? [])],
+        };
+      }
+
+      const hasSavedBook = (current.savedBooks ?? []).some((item) => String(item.id) === String(book.id));
+      return {
+        ...current,
+        savedBooks: hasSavedBook ? current.savedBooks : [normalizedBook, ...(current.savedBooks ?? [])],
+      };
+    });
+  }
 
   return (
     <section className="mx-auto w-full max-w-7xl px-5 py-8">
@@ -209,6 +259,15 @@ export default function MyPage() {
                 읽은 책 수정
               </Link>
             </div>
+            <BookSearchPanel
+              actionLabel="읽은 책 추가"
+              disabledIds={readBooks.map((book) => book.id)}
+              emptyMessage="읽은 책으로 추가할 검색 결과가 없습니다."
+              onSelect={(book) => addBookInteraction(book, "READ")}
+              selectedIds={readBooks.map((book) => book.id)}
+              selectedLabel="이미 읽은 책"
+              title="읽은 책 추가 검색"
+            />
             {!isLoading && readBooks.length === 0 ? (
               <div className="mt-5">
                 <EmptyState
@@ -270,6 +329,15 @@ export default function MyPage() {
             <aside className="rounded-lg border border-[#E5E7EB] bg-white p-5 shadow-sm">
               <p className="text-sm font-semibold text-[#F59E0B]">저장한 책</p>
               <h2 className="mt-2 text-xl font-bold text-[#1E2A38]">다음에 읽을 후보</h2>
+              <BookSearchPanel
+                actionLabel="저장하기"
+                disabledIds={savedBooks.map((book) => book.id)}
+                emptyMessage="저장할 검색 결과가 없습니다."
+                onSelect={(book) => addBookInteraction(book, "SAVE")}
+                selectedIds={savedBooks.map((book) => book.id)}
+                selectedLabel="이미 저장됨"
+                title="저장한 책 추가 검색"
+              />
               {!isLoading && savedBooks.length === 0 ? (
                 <div className="mt-5">
                   <EmptyState

--- a/frontend/src/pages/OnboardingPage.jsx
+++ b/frontend/src/pages/OnboardingPage.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 import { useAuth } from "../App";
+import BookSearchPanel from "../components/BookSearchPanel";
 
 function normalizeCategory(category) {
   return {
@@ -28,6 +29,16 @@ function getInitialCategoryIds(options, myPage) {
 function getInitialBookIds(options, myPage) {
   const readBookIds = new Set((myPage?.readBooks ?? []).map((book) => String(book.id)));
   return options.filter((book) => readBookIds.has(String(book.id))).map((book) => book.id);
+}
+
+function mergeBooks(currentBooks, nextBooks) {
+  const booksById = new Map(currentBooks.map((book) => [String(book.id), book]));
+  nextBooks.forEach((book) => {
+    if (!booksById.has(String(book.id))) {
+      booksById.set(String(book.id), normalizeBook(book));
+    }
+  });
+  return Array.from(booksById.values());
 }
 
 export default function OnboardingPage() {
@@ -107,8 +118,8 @@ export default function OnboardingPage() {
           setSelectedCategoryIds(initialCategoryIds);
           setSelectedBookIds(initialBookIds);
           setIsEditMode(initialCategoryIds.length > 0 || initialBookIds.length > 0);
-          setCanSave(nextCategories.length > 0 && nextBooks.length > 0);
-          if (nextCategories.length === 0 || nextBooks.length === 0) {
+          setCanSave(nextCategories.length > 0);
+          if (nextCategories.length === 0) {
             setMessage("온보딩 선택지가 아직 준비되지 않았습니다. 잠시 후 다시 시도해 주세요.");
           }
         }
@@ -276,6 +287,19 @@ export default function OnboardingPage() {
                 {selectedBookIds.length}권 선택
               </span>
             </div>
+
+            <BookSearchPanel
+              actionLabel="읽은 책 선택"
+              emptyMessage="검색 결과가 없습니다."
+              onResults={(books) => setAvailableBooks((current) => mergeBooks(current, books))}
+              onSelect={(book) => {
+                setAvailableBooks((current) => mergeBooks(current, [book]));
+                setSelectedBookIds((current) => (current.includes(book.id) ? current : [...current, book.id]));
+              }}
+              selectedIds={selectedBookIds}
+              selectedLabel="선택됨"
+              title="읽은 책 검색"
+            />
 
             <div className="mt-5 grid grid-cols-1 gap-4 md:grid-cols-2">
               {availableBooks.length > 0 ? availableBooks.map((book) => {


### PR DESCRIPTION
## 📌 개요
> 어떤 변경 사항인지

- 검색 기반 책 추가 기능 구현
- 내부 DB 기반 책 검색 API 추가
- 온보딩과 마이페이지에서 책 검색 후 읽은 책/저장한 책으로 추가할 수 있도록 UI 및 API 연동

---

## 🔗 관련 이슈
- Closes #30 

---

## ✨ 작업 내용
> 주요 변경 사항

### 🔹 Backend
- `GET /api/books/search` 검색 API 추가
- 제목 또는 저자 기준 부분 일치 검색 구현
- `generalEligible=true` 책만 검색 결과에 포함
- 검색어 최소 길이 검증 추가
- 검색 결과 limit 기본값/최대값 처리
- 검색 API 테스트 추가

### 🔹 Frontend
- 공통 책 검색 컴포넌트 `BookSearchPanel` 추가
- 온보딩 읽은 책 섹션에 검색 UI 추가
- 검색 결과 선택 시 온보딩 저장 요청의 `readBookIds`에 포함
- 마이페이지 읽은 책 섹션에 검색 기반 추가 기능 구현
- 마이페이지 저장한 책 섹션에 검색 기반 저장 기능 구현
- `/api/books/search` 및 `/api/me/books/{bookId}/interactions` 연동
- 온보딩 form 내부 검색 submit 충돌 수정
- 검색 API 연결 실패 시 안내 메시지 개선

---

## 🧪 테스트 결과
- [x] 로컬 테스트 완료
- [x] API 정상 동작 확인
- [x] 에러 케이스 확인

Backend:
- `cd backend`
- `.\gradlew.bat test`
- 결과: 성공

Frontend:
- `cd frontend`
- `npm run build`
- 결과: 성공

수동 확인:
- `/api/books/search?query=투자&limit=10` 응답 `200` 확인
- 온보딩 검색 시 페이지 새로고침 없이 검색 동작 확인
- backend 미실행 시 검색 API 연결 실패 메시지 표시 확인

---

## 📸 스크린샷 (선택)
> UI 변경 시 첨부

- 온보딩 읽은 책 검색 UI
- 마이페이지 읽은 책 추가 검색 UI
- 마이페이지 저장한 책 추가 검색 UI

---

## ⚠️ 주의사항
- 현재 검색 대상은 제목/저자입니다.
- 카테고리/키워드 검색은 후속 확장 대상입니다.
- frontend 검색 기능은 backend 서버가 실행 중이어야 정상 동작합니다.
- `GET /api/books/search`는 공개 조회 API이며, 읽은 책/저장한 책 추가는 기존 인증 API를 사용합니다.
- 온보딩 검색 컴포넌트는 상위 저장 form과 submit 충돌이 나지 않도록 내부 form을 사용하지 않습니다.

---

## 🚀 배포 전 체크리스트
- [x] 빌드 성공 (`npm run build`)
- [x] backend 테스트 성공 (`.\gradlew.bat test`)
- [ ] 환경변수 설정 확인
- [x] DB 영향 여부 확인
- [ ] 실제 배포 환경에서 `/api/books/search` 라우팅 확인

DB 영향:
- schema 변경 없음
- migration 없음
- 신규 테이블/컬럼 없음

---

## 💬 리뷰 포인트
> 리뷰어가 집중해서 봐야 할 부분

- `BookRepository` 검색 쿼리 조건이 적절한지
- 검색어 최소 길이와 limit 정책이 적절한지
- 검색 결과를 `BookSummaryResponse`로 재사용하는 방식이 맞는지
- 온보딩에서 검색 결과 선택 후 기존 `readBookIds` 저장 흐름과 충돌이 없는지
- 마이페이지에서 `READ`, `SAVE` interaction 호출 후 로컬 상태 갱신 방식이 적절한지
- `BookSearchPanel`이 상위 form submit과 충돌하지 않는지
