### PR TITLE
feat: 독서 목적 저장 및 추천 반영(Closes #31)

### DIFF
--- a/backend/src/main/java/com/example/chaeklist/domain/book/service/BookService.java
+++ b/backend/src/main/java/com/example/chaeklist/domain/book/service/BookService.java
@@ -19,6 +19,7 @@ import com.example.chaeklist.domain.book.entity.BookRankingSnapshot;
 import com.example.chaeklist.domain.book.repository.BookRankingSnapshotRepository;
 import com.example.chaeklist.domain.book.repository.BookRepository;
 import com.example.chaeklist.domain.book.repository.CategoryRepository;
+import com.example.chaeklist.domain.mypage.model.ReadingPurpose;
 import com.example.chaeklist.global.auth.AuthenticatedUser;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
@@ -317,6 +318,7 @@ public class BookService {
 
 	private Optional<PersonalizedRecommendation> getPersonalRecommendation(long userId) {
 		Set<String> interestCategories = getInterestCategories(userId);
+		List<ReadingPurpose> readingPurposes = getReadingPurposes(userId);
 		List<Book> readBooks = getInteractedBooks(userId, "READ");
 		List<Book> savedBooks = getSavedBooks(userId);
 		Set<Long> excludedBookIds = getExcludedBookIds(userId);
@@ -331,6 +333,7 @@ public class BookService {
 				.map(book -> scorePersonalizedRecommendation(
 						book,
 						interestCategories,
+						readingPurposes,
 						readCategories,
 						savedCategories,
 						readKeywords,
@@ -344,6 +347,7 @@ public class BookService {
 	private Optional<PersonalizedRecommendation> scorePersonalizedRecommendation(
 			Book book,
 			Set<String> interestCategories,
+			List<ReadingPurpose> readingPurposes,
 			Set<String> readCategories,
 			Set<String> savedCategories,
 			Set<String> readKeywords,
@@ -362,17 +366,22 @@ public class BookService {
 		if (savedCategories.contains(category)) {
 			score += 20;
 		}
+		if (matchesPurposeCategory(category, readingPurposes)) {
+			score += 20;
+		}
 
 		int sharedReadKeywords = sharedKeywordCount(keywords, readKeywords);
 		int sharedSavedKeywords = sharedKeywordCount(keywords, savedKeywords);
+		int sharedPurposeKeywords = sharedPurposeKeywordCount(keywords, readingPurposes);
 		score += sharedReadKeywords * 10;
 		score += sharedSavedKeywords * 8;
+		score += sharedPurposeKeywords * 8;
 
 		if (score <= 0) {
 			return Optional.empty();
 		}
 		return Optional.of(new PersonalizedRecommendation(book, recommendationReason(book, interestCategories, readCategories,
-				savedCategories, readKeywords, savedKeywords), score));
+				savedCategories, readKeywords, savedKeywords, readingPurposes), score));
 	}
 
 	private String recommendationReason(
@@ -381,7 +390,8 @@ public class BookService {
 			Set<String> readCategories,
 			Set<String> savedCategories,
 			Set<String> readKeywords,
-			Set<String> savedKeywords
+			Set<String> savedKeywords,
+			List<ReadingPurpose> readingPurposes
 	) {
 		String category = book.category();
 		if (interestCategories.contains(category)) {
@@ -408,6 +418,16 @@ public class BookService {
 			return "읽은 책과 비슷한 " + category + " 분야의 교양 도서입니다.";
 		}
 
+		Optional<ReadingPurpose> categoryPurpose = firstPurposeByCategory(category, readingPurposes);
+		if (categoryPurpose.isPresent()) {
+			return categoryPurpose.get().label() + " 목적에 맞는 " + category + " 분야의 교양 도서입니다.";
+		}
+
+		Optional<String> purposeKeyword = firstSharedPurposeKeyword(book.keywords(), readingPurposes);
+		if (purposeKeyword.isPresent()) {
+			return purposeKeyword.get() + " 키워드가 선택한 독서 목적과 맞아 추천합니다.";
+		}
+
 		return FALLBACK_RECOMMENDATION_REASON;
 	}
 
@@ -429,6 +449,18 @@ public class BookService {
 				WHERE uic.user_id = ?
 					AND c.is_active = TRUE
 				""", String.class, userId));
+	}
+
+	private List<ReadingPurpose> getReadingPurposes(long userId) {
+		return jdbcTemplate.queryForList("""
+				SELECT purpose_code
+				FROM user_reading_purposes
+				WHERE user_id = ?
+				ORDER BY created_at ASC, purpose_code ASC
+				""", String.class, userId).stream()
+				.map(ReadingPurpose::fromCode)
+				.flatMap(Optional::stream)
+				.toList();
 	}
 
 	private List<Book> getInteractedBooks(long userId, String interactionType) {
@@ -497,6 +529,31 @@ public class BookService {
 		return keywords.stream()
 				.filter(referenceKeywords::contains)
 				.findFirst();
+	}
+
+	private boolean matchesPurposeCategory(String category, List<ReadingPurpose> readingPurposes) {
+		return readingPurposes.stream()
+				.anyMatch(purpose -> purpose.categoryNames().contains(category));
+	}
+
+	private int sharedPurposeKeywordCount(List<String> keywords, List<ReadingPurpose> readingPurposes) {
+		Set<String> purposeKeywords = readingPurposes.stream()
+				.flatMap(purpose -> purpose.keywords().stream())
+				.collect(java.util.stream.Collectors.toSet());
+		return sharedKeywordCount(keywords, purposeKeywords);
+	}
+
+	private Optional<ReadingPurpose> firstPurposeByCategory(String category, List<ReadingPurpose> readingPurposes) {
+		return readingPurposes.stream()
+				.filter(purpose -> purpose.categoryNames().contains(category))
+				.findFirst();
+	}
+
+	private Optional<String> firstSharedPurposeKeyword(List<String> keywords, List<ReadingPurpose> readingPurposes) {
+		Set<String> purposeKeywords = readingPurposes.stream()
+				.flatMap(purpose -> purpose.keywords().stream())
+				.collect(java.util.stream.Collectors.toSet());
+		return firstSharedKeyword(keywords, purposeKeywords);
 	}
 
 	private List<BookRankingSnapshot> findRanking(String category, String period, int limit) {

--- a/backend/src/main/java/com/example/chaeklist/domain/book/service/BookService.java
+++ b/backend/src/main/java/com/example/chaeklist/domain/book/service/BookService.java
@@ -433,7 +433,7 @@ public class BookService {
 
 	private void saveRecommendation(long userId, PersonalizedRecommendation recommendation) {
 		jdbcTemplate.update("""
-				INSERT INTO recommendations (user_id, book_id, recommendation_type, reason, score, generated_at)
+				INSERT INTO recommendations (user_id, book_id, recommendation_type, reason, score, created_at)
 				VALUES (?, ?, 'CONTENT_BASED', ?, ?, CURRENT_TIMESTAMP)
 				ON DUPLICATE KEY UPDATE
 					reason = VALUES(reason),

--- a/backend/src/main/java/com/example/chaeklist/domain/mypage/dto/MyPageRecommendationResponse.java
+++ b/backend/src/main/java/com/example/chaeklist/domain/mypage/dto/MyPageRecommendationResponse.java
@@ -19,6 +19,6 @@ public record MyPageRecommendationResponse(
 		@Schema(description = "추천 점수", example = "92")
 		int score,
 		@Schema(description = "추천 생성 시각")
-		LocalDateTime generatedAt
+		LocalDateTime createdAt
 ) {
 }

--- a/backend/src/main/java/com/example/chaeklist/domain/mypage/dto/MyPageResponse.java
+++ b/backend/src/main/java/com/example/chaeklist/domain/mypage/dto/MyPageResponse.java
@@ -11,6 +11,8 @@ public record MyPageResponse(
 		AuthUserResponse user,
 		@Schema(description = "관심 분야")
 		List<MyPageInterestResponse> interests,
+		@Schema(description = "독서 목적")
+		List<ReadingPurposeResponse> readingPurposes,
 		@Schema(description = "읽은 책")
 		List<MyPageBookResponse> readBooks,
 		@Schema(description = "저장한 책")

--- a/backend/src/main/java/com/example/chaeklist/domain/mypage/dto/OnboardingOptionsResponse.java
+++ b/backend/src/main/java/com/example/chaeklist/domain/mypage/dto/OnboardingOptionsResponse.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 public record OnboardingOptionsResponse(
 		List<OnboardingCategoryOptionResponse> categories,
-		List<OnboardingBookOptionResponse> books
+		List<OnboardingBookOptionResponse> books,
+		List<ReadingPurposeResponse> readingPurposes
 ) {
 }

--- a/backend/src/main/java/com/example/chaeklist/domain/mypage/dto/OnboardingRequest.java
+++ b/backend/src/main/java/com/example/chaeklist/domain/mypage/dto/OnboardingRequest.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 public record OnboardingRequest(
 		List<Long> categoryIds,
-		List<Long> readBookIds
+		List<Long> readBookIds,
+		List<String> readingPurposeCodes
 ) {
 }

--- a/backend/src/main/java/com/example/chaeklist/domain/mypage/dto/ReadingPurposeResponse.java
+++ b/backend/src/main/java/com/example/chaeklist/domain/mypage/dto/ReadingPurposeResponse.java
@@ -1,0 +1,14 @@
+package com.example.chaeklist.domain.mypage.dto;
+
+import com.example.chaeklist.domain.mypage.model.ReadingPurpose;
+
+public record ReadingPurposeResponse(
+		String code,
+		String label,
+		String description
+) {
+
+	public static ReadingPurposeResponse from(ReadingPurpose purpose) {
+		return new ReadingPurposeResponse(purpose.code(), purpose.label(), purpose.description());
+	}
+}

--- a/backend/src/main/java/com/example/chaeklist/domain/mypage/model/ReadingPurpose.java
+++ b/backend/src/main/java/com/example/chaeklist/domain/mypage/model/ReadingPurpose.java
@@ -1,0 +1,84 @@
+package com.example.chaeklist.domain.mypage.model;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+public enum ReadingPurpose {
+	KNOWLEDGE(
+			"지식 확장",
+			"인문, 역사, 사회처럼 시야를 넓히는 책을 찾습니다.",
+			Set.of("인문", "경제", "역사", "사회"),
+			Set.of("AI", "역사", "사회")
+	),
+	SELF_IMPROVEMENT(
+			"자기계발",
+			"습관, 집중, 루틴처럼 실천에 도움이 되는 책을 찾습니다.",
+			Set.of("자기계발"),
+			Set.of("습관", "집중", "루틴")
+	),
+	ECONOMY_INVESTING(
+			"경제/투자 이해",
+			"경제 흐름과 투자 감각을 이해할 수 있는 책을 찾습니다.",
+			Set.of("경제"),
+			Set.of("투자", "돈", "시장")
+	),
+	LIGHT_READING(
+			"가벼운 독서",
+			"소설, 에세이처럼 부담 없이 읽을 수 있는 책을 찾습니다.",
+			Set.of("소설", "에세이"),
+			Set.of("일상", "관계")
+	),
+	TREND_TRACKING(
+			"트렌드 파악",
+			"AI, 기술, 트렌드처럼 지금 많이 이야기되는 주제를 찾습니다.",
+			Set.of("경제"),
+			Set.of("AI", "도파민", "트렌드", "기술", "투자")
+	);
+
+	private final String label;
+	private final String description;
+	private final Set<String> categoryNames;
+	private final Set<String> keywords;
+
+	ReadingPurpose(String label, String description, Set<String> categoryNames, Set<String> keywords) {
+		this.label = label;
+		this.description = description;
+		this.categoryNames = categoryNames;
+		this.keywords = keywords;
+	}
+
+	public String code() {
+		return name();
+	}
+
+	public String label() {
+		return label;
+	}
+
+	public String description() {
+		return description;
+	}
+
+	public Set<String> categoryNames() {
+		return categoryNames;
+	}
+
+	public Set<String> keywords() {
+		return keywords;
+	}
+
+	public static List<ReadingPurpose> options() {
+		return Arrays.asList(values());
+	}
+
+	public static Optional<ReadingPurpose> fromCode(String code) {
+		if (code == null || code.isBlank()) {
+			return Optional.empty();
+		}
+		return Arrays.stream(values())
+				.filter(purpose -> purpose.name().equals(code.trim().toUpperCase()))
+				.findFirst();
+	}
+}

--- a/backend/src/main/java/com/example/chaeklist/domain/mypage/service/MyPageService.java
+++ b/backend/src/main/java/com/example/chaeklist/domain/mypage/service/MyPageService.java
@@ -19,6 +19,8 @@ import com.example.chaeklist.domain.mypage.dto.OnboardingCategoryOptionResponse;
 import com.example.chaeklist.domain.mypage.dto.OnboardingOptionsResponse;
 import com.example.chaeklist.domain.mypage.dto.OnboardingRequest;
 import com.example.chaeklist.domain.mypage.dto.OnboardingStatusResponse;
+import com.example.chaeklist.domain.mypage.dto.ReadingPurposeResponse;
+import com.example.chaeklist.domain.mypage.model.ReadingPurpose;
 import com.example.chaeklist.global.auth.AuthenticatedUser;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Service;
@@ -40,6 +42,7 @@ public class MyPageService {
 		return new MyPageResponse(
 				AuthUserResponse.from(user),
 				getInterests(user.id()),
+				getReadingPurposes(user.id()),
 				getBooksByInteraction(user.id(), "READ", DEFAULT_LIMIT),
 				getSavedBooks(user.id(), DEFAULT_LIMIT),
 				getRecommendationHistory(user.id(), DEFAULT_LIMIT)
@@ -56,13 +59,18 @@ public class MyPageService {
 	}
 
 	public OnboardingOptionsResponse getOnboardingOptions() {
-		return new OnboardingOptionsResponse(getOnboardingCategories(), getOnboardingBooks(DEFAULT_LIMIT));
+		return new OnboardingOptionsResponse(
+				getOnboardingCategories(),
+				getOnboardingBooks(DEFAULT_LIMIT),
+				getReadingPurposeOptions()
+		);
 	}
 
 	@Transactional
 	public void saveOnboarding(AuthenticatedUser user, OnboardingRequest request) {
 		List<Long> categoryIds = normalizeIds(request == null ? null : request.categoryIds());
 		List<Long> readBookIds = normalizeIds(request == null ? null : request.readBookIds());
+		List<ReadingPurpose> readingPurposes = normalizeReadingPurposes(request == null ? null : request.readingPurposeCodes());
 
 		if (categoryIds.isEmpty()) {
 			throw new OnboardingRequestException("At least one category is required.");
@@ -85,6 +93,14 @@ public class MyPageService {
 		jdbcTemplate.update("DELETE FROM user_book_interactions WHERE user_id = ? AND interaction_type = 'READ'", user.id());
 		for (Long bookId : readBookIds) {
 			insertReadInteraction(user.id(), bookId);
+		}
+
+		jdbcTemplate.update("DELETE FROM user_reading_purposes WHERE user_id = ?", user.id());
+		for (ReadingPurpose purpose : readingPurposes) {
+			jdbcTemplate.update("""
+					INSERT INTO user_reading_purposes (user_id, purpose_code, created_at)
+					VALUES (?, ?, CURRENT_TIMESTAMP)
+					""", user.id(), purpose.code());
 		}
 
 		jdbcTemplate.update("""
@@ -167,6 +183,12 @@ public class MyPageService {
 		);
 	}
 
+	private List<ReadingPurposeResponse> getReadingPurposeOptions() {
+		return ReadingPurpose.options().stream()
+				.map(ReadingPurposeResponse::from)
+				.toList();
+	}
+
 	private List<MyPageInterestResponse> getInterests(long userId) {
 		return jdbcTemplate.query("""
 				SELECT
@@ -195,6 +217,19 @@ public class MyPageService {
 		);
 	}
 
+	private List<ReadingPurposeResponse> getReadingPurposes(long userId) {
+		return jdbcTemplate.queryForList("""
+				SELECT purpose_code
+				FROM user_reading_purposes
+				WHERE user_id = ?
+				ORDER BY created_at ASC, purpose_code ASC
+				""", String.class, userId).stream()
+				.map(ReadingPurpose::fromCode)
+				.flatMap(java.util.Optional::stream)
+				.map(ReadingPurposeResponse::from)
+				.toList();
+	}
+
 	private List<Long> normalizeIds(List<Long> ids) {
 		if (ids == null) {
 			return List.of();
@@ -203,6 +238,25 @@ public class MyPageService {
 				.filter(id -> id != null && id > 0)
 				.distinct()
 				.toList();
+	}
+
+	private List<ReadingPurpose> normalizeReadingPurposes(List<String> purposeCodes) {
+		if (purposeCodes == null) {
+			return List.of();
+		}
+
+		List<ReadingPurpose> purposes = purposeCodes.stream()
+				.filter(code -> code != null && !code.isBlank())
+				.map(code -> ReadingPurpose.fromCode(code)
+						.orElseThrow(() -> new OnboardingRequestException("Unsupported reading purpose code.")))
+				.distinct()
+				.toList();
+
+		if (purposes.size() > 3) {
+			throw new OnboardingRequestException("Reading purposes must be 3 or fewer.");
+		}
+
+		return purposes;
 	}
 
 	private void validateCategories(List<Long> categoryIds) {

--- a/backend/src/main/java/com/example/chaeklist/domain/mypage/service/MyPageService.java
+++ b/backend/src/main/java/com/example/chaeklist/domain/mypage/service/MyPageService.java
@@ -492,12 +492,12 @@ public class MyPageService {
 					r.recommendation_type,
 					COALESCE(NULLIF(r.reason, ''), '사용자 관심 분야와 도서 행동을 바탕으로 추천했습니다.') AS reason,
 					r.score,
-					r.generated_at
+					r.created_at
 				FROM recommendations r
 				JOIN books b ON b.id = r.book_id
 				WHERE r.user_id = ?
 					AND b.is_general_eligible = TRUE
-				ORDER BY r.generated_at DESC, r.score DESC, r.id DESC
+				ORDER BY r.created_at DESC, r.score DESC, r.id DESC
 				LIMIT ?
 				""",
 				(resultSet, rowNumber) -> new MyPageRecommendationResponse(
@@ -507,7 +507,7 @@ public class MyPageService {
 						resultSet.getString("reason"),
 						resultSet.getString("recommendation_type"),
 						toRecommendationScore(resultSet.getDouble("score")),
-						readLocalDateTime(resultSet, "generated_at")
+						readLocalDateTime(resultSet, "created_at")
 				),
 				userId,
 				limit

--- a/backend/src/test/java/com/example/chaeklist/BookControllerTest.java
+++ b/backend/src/test/java/com/example/chaeklist/BookControllerTest.java
@@ -343,7 +343,7 @@ class BookControllerTest {
 		org.assertj.core.api.Assertions.assertThat(countRecommendations(userId, 411)).isEqualTo(1);
 		org.assertj.core.api.Assertions.assertThat(recommendationReason(userId, 411))
 				.isEqualTo("관심 분야로 선택한 경제 분야의 교양 도서입니다.");
-		java.time.LocalDateTime firstGeneratedAt = recommendationGeneratedAt(userId, 411);
+		java.time.LocalDateTime firstCreatedAt = recommendationCreatedAt(userId, 411);
 
 		mockMvc.perform(get("/api/me/home")
 						.header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
@@ -351,7 +351,7 @@ class BookControllerTest {
 				.andExpect(jsonPath("$.todayRecommendation.id", is("411")));
 
 		org.assertj.core.api.Assertions.assertThat(countRecommendations(userId, 411)).isEqualTo(1);
-		org.assertj.core.api.Assertions.assertThat(recommendationGeneratedAt(userId, 411)).isEqualTo(firstGeneratedAt);
+		org.assertj.core.api.Assertions.assertThat(recommendationCreatedAt(userId, 411)).isEqualTo(firstCreatedAt);
 	}
 
 	@Test
@@ -674,7 +674,7 @@ class BookControllerTest {
 					recommendation_type VARCHAR(30) NOT NULL,
 					reason VARCHAR(255),
 					score DECIMAL(12,4) NOT NULL DEFAULT 0.0000,
-					generated_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+					created_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
 					CONSTRAINT uk_recommendations_user_book_type UNIQUE (user_id, book_id, recommendation_type)
 				)
 				""");
@@ -700,9 +700,9 @@ class BookControllerTest {
 				""", String.class, userId, bookId);
 	}
 
-	private java.time.LocalDateTime recommendationGeneratedAt(long userId, long bookId) {
+	private java.time.LocalDateTime recommendationCreatedAt(long userId, long bookId) {
 		java.sql.Timestamp timestamp = jdbcTemplate.queryForObject("""
-				SELECT generated_at
+				SELECT created_at
 				FROM recommendations
 				WHERE user_id = ?
 					AND book_id = ?

--- a/backend/src/test/java/com/example/chaeklist/BookControllerTest.java
+++ b/backend/src/test/java/com/example/chaeklist/BookControllerTest.java
@@ -414,6 +414,30 @@ class BookControllerTest {
 
 	@Test
 	@Transactional
+	void returnsPersonalHomeRecommendationFromReadingPurpose() throws Exception {
+		createUserInterestCategoriesTable();
+		createUserBookInteractionsTable();
+		long userId = userId();
+		String accessToken = loginAndExtractAccessToken();
+
+		insertCategory(581, "소설");
+		insertCategory(582, "경제");
+		insertBook(591, "가벼운 소설 후보", true);
+		insertBook(592, "경제 후보", true);
+		insertBookCategory(591, 581);
+		insertBookCategory(592, 582);
+		insertReadingPurpose(userId, "LIGHT_READING");
+
+		mockMvc.perform(get("/api/me/home")
+						.header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.todayRecommendation.id", is("591")))
+				.andExpect(jsonPath("$.todayRecommendation.recommendationReason",
+						is("가벼운 독서 목적에 맞는 소설 분야의 교양 도서입니다.")));
+	}
+
+	@Test
+	@Transactional
 	void ignoresUnsavedBookForPersonalHomeRecommendation() throws Exception {
 		createUserInterestCategoriesTable();
 		createUserBookInteractionsTable();
@@ -531,6 +555,18 @@ class BookControllerTest {
 					created_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP
 				)
 				""");
+		createUserReadingPurposesTable();
+	}
+
+	private void createUserReadingPurposesTable() {
+		jdbcTemplate.execute("""
+				CREATE TABLE IF NOT EXISTS user_reading_purposes (
+					user_id BIGINT NOT NULL,
+					purpose_code VARCHAR(50) NOT NULL,
+					created_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+					PRIMARY KEY (user_id, purpose_code)
+				)
+				""");
 	}
 
 	private long userId() {
@@ -599,6 +635,13 @@ class BookControllerTest {
 				INSERT INTO user_interest_categories (user_id, category_id, created_at)
 				VALUES (?, ?, CURRENT_TIMESTAMP)
 				""", userId, categoryId);
+	}
+
+	private void insertReadingPurpose(long userId, String purposeCode) {
+		jdbcTemplate.update("""
+				INSERT INTO user_reading_purposes (user_id, purpose_code, created_at)
+				VALUES (?, ?, CURRENT_TIMESTAMP)
+				""", userId, purposeCode);
 	}
 
 	private void insertRankingSnapshot(long id, long bookId, Long categoryId, int rankPosition) {

--- a/backend/src/test/java/com/example/chaeklist/MyPageControllerTest.java
+++ b/backend/src/test/java/com/example/chaeklist/MyPageControllerTest.java
@@ -52,6 +52,7 @@ class MyPageControllerTest {
 		insertBookCategory(903, 802);
 		insertInterest(userId, 801);
 		insertInterest(userId, 802);
+		insertReadingPurpose(userId, "KNOWLEDGE");
 		insertInteraction(userId, 901, "READ", "2026-04-20 10:00:00");
 		insertInteraction(userId, 901, "VIEW", "2026-04-20 10:01:00");
 		insertInteraction(userId, 902, "SAVE", "2026-04-21 10:00:00");
@@ -69,6 +70,9 @@ class MyPageControllerTest {
 				.andExpect(jsonPath("$.interests", hasSize(2)))
 				.andExpect(jsonPath("$.interests[0].id", is(801)))
 				.andExpect(jsonPath("$.interests[0].label", is("인문")))
+				.andExpect(jsonPath("$.readingPurposes", hasSize(1)))
+				.andExpect(jsonPath("$.readingPurposes[0].code", is("KNOWLEDGE")))
+				.andExpect(jsonPath("$.readingPurposes[0].label", is("지식 확장")))
 				.andExpect(jsonPath("$.readBooks", hasSize(1)))
 				.andExpect(jsonPath("$.readBooks[0].id", is("901")))
 				.andExpect(jsonPath("$.readBooks[0].title", is("느리게 읽는 법")))
@@ -111,7 +115,10 @@ class MyPageControllerTest {
 				.andExpect(jsonPath("$.books[0].title", is("겹치는 분야의 책")))
 				.andExpect(jsonPath("$.books[0].category", is("인문")))
 				.andExpect(jsonPath("$.books[1].id", is("901")))
-				.andExpect(jsonPath("$.books[2].id", is("902")));
+				.andExpect(jsonPath("$.books[2].id", is("902")))
+				.andExpect(jsonPath("$.readingPurposes", hasSize(5)))
+				.andExpect(jsonPath("$.readingPurposes[0].code", is("KNOWLEDGE")))
+				.andExpect(jsonPath("$.readingPurposes[0].label", is("지식 확장")));
 	}
 
 	@Test
@@ -124,7 +131,8 @@ class MyPageControllerTest {
 						.content("""
 								{
 								  "categoryIds": [801],
-								  "readBookIds": [902]
+								  "readBookIds": [902],
+								  "readingPurposeCodes": ["ECONOMY_INVESTING", "TREND_TRACKING"]
 								}
 								"""))
 				.andExpect(status().isOk())
@@ -141,8 +149,29 @@ class MyPageControllerTest {
 				.andExpect(jsonPath("$.interests", hasSize(1)))
 				.andExpect(jsonPath("$.interests[0].id", is(801)))
 				.andExpect(jsonPath("$.interests[0].label", is("인문")))
+				.andExpect(jsonPath("$.readingPurposes", hasSize(2)))
+				.andExpect(jsonPath("$.readingPurposes[0].code", is("ECONOMY_INVESTING")))
+				.andExpect(jsonPath("$.readingPurposes[1].code", is("TREND_TRACKING")))
 				.andExpect(jsonPath("$.readBooks", hasSize(1)))
 				.andExpect(jsonPath("$.readBooks[0].id", is("902")));
+	}
+
+	@Test
+	void rejectsUnsupportedReadingPurposeCode() throws Exception {
+		String accessToken = loginAndExtractAccessToken();
+
+		mockMvc.perform(put("/api/me/onboarding")
+						.header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+						.contentType(MediaType.APPLICATION_JSON)
+						.content("""
+								{
+								  "categoryIds": [801],
+								  "readBookIds": [902],
+								  "readingPurposeCodes": ["UNKNOWN"]
+								}
+								"""))
+				.andExpect(status().isBadRequest())
+				.andExpect(jsonPath("$.message", is("Unsupported reading purpose code.")));
 	}
 
 	@Test
@@ -388,6 +417,14 @@ class MyPageControllerTest {
 					generated_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP
 				)
 				""");
+		jdbcTemplate.execute("""
+				CREATE TABLE IF NOT EXISTS user_reading_purposes (
+					user_id BIGINT NOT NULL,
+					purpose_code VARCHAR(50) NOT NULL,
+					created_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+					PRIMARY KEY (user_id, purpose_code)
+				)
+				""");
 	}
 
 	private long userId() {
@@ -434,6 +471,13 @@ class MyPageControllerTest {
 				INSERT INTO user_interest_categories (user_id, category_id, created_at)
 				VALUES (?, ?, CURRENT_TIMESTAMP)
 				""", userId, categoryId);
+	}
+
+	private void insertReadingPurpose(long userId, String purposeCode) {
+		jdbcTemplate.update("""
+				INSERT INTO user_reading_purposes (user_id, purpose_code, created_at)
+				VALUES (?, ?, CURRENT_TIMESTAMP)
+				""", userId, purposeCode);
 	}
 
 	private void insertInteraction(long userId, long bookId, String interactionType, String createdAt) {

--- a/backend/src/test/java/com/example/chaeklist/MyPageControllerTest.java
+++ b/backend/src/test/java/com/example/chaeklist/MyPageControllerTest.java
@@ -414,7 +414,7 @@ class MyPageControllerTest {
 					recommendation_type VARCHAR(30) NOT NULL,
 					reason VARCHAR(255),
 					score DECIMAL(12,4) NOT NULL DEFAULT 0.0000,
-					generated_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP
+					created_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP
 				)
 				""");
 		jdbcTemplate.execute("""
@@ -489,7 +489,7 @@ class MyPageControllerTest {
 
 	private void insertRecommendation(long userId, long bookId) {
 		jdbcTemplate.update("""
-				INSERT INTO recommendations (user_id, book_id, recommendation_type, reason, score, generated_at)
+				INSERT INTO recommendations (user_id, book_id, recommendation_type, reason, score, created_at)
 				VALUES (?, ?, 'CONTENT_BASED', '인문 관심 분야와 읽은 책 기록을 바탕으로 추천했습니다.', 0.9200, CURRENT_TIMESTAMP)
 				""", userId, bookId);
 	}

--- a/docs/mysql-ddl.sql
+++ b/docs/mysql-ddl.sql
@@ -208,7 +208,7 @@ CREATE TABLE recommendations (
   recommendation_type VARCHAR(30) NOT NULL,
   reason VARCHAR(255) NULL,
   score DECIMAL(12,4) NOT NULL DEFAULT 0.0000,
-  generated_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+  created_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
   PRIMARY KEY (id),
   UNIQUE KEY uk_recommendations_user_book_type (user_id, book_id, recommendation_type),
   KEY idx_recommendations_user_score (user_id, score),

--- a/docs/plan/2026-04-29/follow-up-plan.md
+++ b/docs/plan/2026-04-29/follow-up-plan.md
@@ -19,8 +19,8 @@
 - 홈 개인화 추천 이유를 관심 분야, 읽은 책 키워드, 저장한 책 키워드, 읽은 책 카테고리, 저장한 책 카테고리 기준으로 구체화했다.
 - 홈 개인화 추천이 선택되면 `recommendations`에 `CONTENT_BASED` 유형으로 저장한다.
 - `recommendations`의 `(user_id, book_id, recommendation_type)` unique key를 기준으로 중복 저장을 방지한다.
-- 기존 추천이 다시 생성되면 `reason`, `score`만 갱신하고 `generated_at`은 최초 추천 시각으로 유지한다.
-- 마이페이지 추천 히스토리에서 저장된 reason, source, score, generatedAt을 표시한다.
+- 기존 추천이 다시 생성되면 `reason`, `score`만 갱신하고 `created_at`은 최초 추천 시각으로 유지한다.
+- 마이페이지 추천 히스토리에서 저장된 reason, source, score, createdAt을 표시한다.
 - 홈 화면에서 API가 정상적으로 빈 배열이나 `todayRecommendation: null`을 반환할 때 mock 데이터로 덮어쓰지 않도록 정리했다.
 - 홈의 급상승, 인기, 카테고리 랭킹 빈 상태 문구를 추가했다.
 

--- a/docs/plan/2026-04-29/mvp-gap-and-expansion-check-plan.md
+++ b/docs/plan/2026-04-29/mvp-gap-and-expansion-check-plan.md
@@ -43,7 +43,7 @@ README의 MVP와 핵심 해결책을 기준으로 1차 MVP는 다음 축으로 �
 
 - 홈 개인화 추천은 관심 분야, 읽은 책, 저장한 책의 카테고리/키워드를 기반으로 점수를 계산한다.
 - 추천 결과는 `recommendations`에 `CONTENT_BASED` 유형으로 저장된다.
-- 마이페이지에서 추천 히스토리 reason, source, score, generatedAt을 확인할 수 있다.
+- 마이페이지에서 추천 히스토리 reason, source, score, createdAt을 확인할 수 있다.
 - `READ`, `DISMISS` 책은 개인 추천 후보에서 제외된다.
 
 확장 확인 필요:

--- a/frontend/src/pages/HomePage.jsx
+++ b/frontend/src/pages/HomePage.jsx
@@ -157,7 +157,7 @@ export default function HomePage() {
           </h1>
           <p className="mt-4 text-sm leading-6 text-[#6B7280]">
             {currentUser
-              ? "관심 분야, 읽은 책, 저장한 책을 바탕으로 오늘의 추천과 추천 이유를 함께 보여줍니다."
+              ? "관심 분야, 독서 목적, 읽은 책, 저장한 책을 바탕으로 오늘의 추천과 추천 이유를 함께 보여줍니다."
               : "현재 인기 책, 급상승 책, 카테고리별 랭킹을 먼저 확인하고 필요할 때 로그인하세요."}
           </p>
           <div className="mt-6">

--- a/frontend/src/pages/MyPage.jsx
+++ b/frontend/src/pages/MyPage.jsx
@@ -344,9 +344,9 @@ export default function MyPage() {
                           </Link>
                           <p className="mt-1 break-keep text-sm leading-6 text-[#6B7280]">{history.reason}</p>
                         </div>
-                        {formatDate(history.generatedAt) ? (
+                        {formatDate(history.createdAt) ? (
                           <span className="shrink-0 rounded-full border border-[#E5E7EB] px-3 py-1 text-xs text-[#6B7280]">
-                            {formatDate(history.generatedAt)}
+                            {formatDate(history.createdAt)}
                           </span>
                         ) : null}
                       </div>

--- a/frontend/src/pages/MyPage.jsx
+++ b/frontend/src/pages/MyPage.jsx
@@ -113,6 +113,7 @@ export default function MyPage() {
 
   const user = myPage?.user ?? currentUser;
   const interestProfiles = myPage?.interests ?? [];
+  const readingPurposes = myPage?.readingPurposes ?? [];
   const readBooks = myPage?.readBooks ?? [];
   const savedBooks = myPage?.savedBooks ?? [];
   const recommendationHistory = myPage?.recommendationHistory ?? [];
@@ -179,9 +180,10 @@ export default function MyPage() {
             </div>
           </div>
 
-          <div className="mt-6 grid grid-cols-3 gap-2">
+          <div className="mt-6 grid grid-cols-2 gap-2 sm:grid-cols-4 lg:grid-cols-2">
             {[
               ["관심", interestProfiles.length],
+              ["목적", readingPurposes.length],
               ["읽은 책", readBooks.length],
               ["추천", recommendationHistory.length],
             ].map(([label, value]) => (
@@ -240,6 +242,40 @@ export default function MyPage() {
                       <div className="h-2 rounded-full bg-[#4CAF50]" style={{ width: `${interest.score}%` }} />
                     </div>
                     <p className="mt-3 text-sm leading-6 text-[#6B7280]">{interest.description}</p>
+                  </article>
+                ))}
+              </div>
+            )}
+          </section>
+
+          <section className="rounded-lg border border-[#E5E7EB] bg-white p-5 shadow-sm">
+            <div className="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
+              <div>
+                <p className="text-sm font-semibold text-[#1E2A38]">독서 목적</p>
+                <h2 className="mt-2 text-2xl font-bold text-[#1E2A38]">추천 이유를 구체화하는 기준</h2>
+              </div>
+              <Link
+                className="inline-flex rounded-md border border-[#E5E7EB] px-3 py-2 text-sm font-semibold text-[#1E2A38] transition hover:border-[#1E2A38]"
+                to="/onboarding?section=reading-purposes"
+              >
+                독서 목적 수정
+              </Link>
+            </div>
+
+            {!isLoading && readingPurposes.length === 0 ? (
+              <div className="mt-5">
+                <EmptyState
+                  actionLabel="독서 목적 선택"
+                  message="독서 목적을 선택하면 추천 이유가 더 구체화됩니다."
+                  to="/onboarding?section=reading-purposes"
+                />
+              </div>
+            ) : (
+              <div className="mt-5 grid grid-cols-1 gap-4 md:grid-cols-3">
+                {readingPurposes.map((purpose) => (
+                  <article className="rounded-lg border border-[#E5E7EB] p-4" key={purpose.code}>
+                    <h3 className="font-bold text-[#1E2A38]">{purpose.label}</h3>
+                    <p className="mt-3 text-sm leading-6 text-[#6B7280]">{purpose.description}</p>
                   </article>
                 ))}
               </div>

--- a/frontend/src/pages/OnboardingPage.jsx
+++ b/frontend/src/pages/OnboardingPage.jsx
@@ -21,9 +21,22 @@ function normalizeBook(book) {
   };
 }
 
+function normalizeReadingPurpose(purpose) {
+  return {
+    code: purpose.code ?? purpose.purposeCode,
+    label: purpose.label ?? purpose.name ?? "독서 목적",
+    description: purpose.description ?? "선택한 독서 목적을 추천 이유에 반영합니다.",
+  };
+}
+
 function getInitialCategoryIds(options, myPage) {
   const interestIds = new Set((myPage?.interests ?? []).map((interest) => String(interest.id)));
   return options.filter((category) => interestIds.has(String(category.id))).map((category) => category.id);
+}
+
+function getInitialReadingPurposeCodes(options, myPage) {
+  const purposeCodes = new Set((myPage?.readingPurposes ?? []).map((purpose) => String(purpose.code)));
+  return options.filter((purpose) => purposeCodes.has(String(purpose.code))).map((purpose) => purpose.code);
 }
 
 function getInitialBookIds(options, myPage) {
@@ -47,8 +60,10 @@ export default function OnboardingPage() {
   const navigate = useNavigate();
   const [availableCategories, setAvailableCategories] = useState([]);
   const [availableBooks, setAvailableBooks] = useState([]);
+  const [availableReadingPurposes, setAvailableReadingPurposes] = useState([]);
   const [selectedCategoryIds, setSelectedCategoryIds] = useState([]);
   const [selectedBookIds, setSelectedBookIds] = useState([]);
+  const [selectedReadingPurposeCodes, setSelectedReadingPurposeCodes] = useState([]);
   const [isEditMode, setIsEditMode] = useState(false);
   const [isLoading, setIsLoading] = useState(true);
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -56,17 +71,25 @@ export default function OnboardingPage() {
   const [errorMessage, setErrorMessage] = useState("");
   const [canSave, setCanSave] = useState(false);
 
-  const canSubmit = canSave && selectedCategoryIds.length > 0 && selectedBookIds.length > 0 && !isSubmitting;
+  const canSubmit =
+    canSave &&
+    selectedCategoryIds.length > 0 &&
+    selectedReadingPurposeCodes.length > 0 &&
+    selectedReadingPurposeCodes.length <= 3 &&
+    selectedBookIds.length > 0 &&
+    !isSubmitting;
   const focusedSection = new URLSearchParams(location.search).get("section");
   const isInterestFocused = focusedSection === "interests";
+  const isPurposeFocused = focusedSection === "reading-purposes";
   const isReadBooksFocused = focusedSection === "read-books";
 
   const selectedSummary = useMemo(
     () => ({
       categories: availableCategories.filter((category) => selectedCategoryIds.includes(category.id)),
+      readingPurposes: availableReadingPurposes.filter((purpose) => selectedReadingPurposeCodes.includes(purpose.code)),
       books: availableBooks.filter((book) => selectedBookIds.includes(book.id)),
     }),
-    [availableBooks, availableCategories, selectedBookIds, selectedCategoryIds],
+    [availableBooks, availableCategories, availableReadingPurposes, selectedBookIds, selectedCategoryIds, selectedReadingPurposeCodes],
   );
 
   useEffect(() => {
@@ -107,19 +130,23 @@ export default function OnboardingPage() {
         const options = await optionsResponse.json();
         const nextCategories = (options.categories ?? options.interestCategories ?? []).map(normalizeCategory).filter((category) => category.id);
         const nextBooks = (options.books ?? options.readableBooks ?? []).map(normalizeBook).filter((book) => book.id);
+        const nextReadingPurposes = (options.readingPurposes ?? []).map(normalizeReadingPurpose).filter((purpose) => purpose.code);
         const myPageResponse = await fetch("/api/me/mypage", { headers });
         const myPage = myPageResponse.ok ? await myPageResponse.json() : null;
         const initialCategoryIds = getInitialCategoryIds(nextCategories, myPage);
+        const initialReadingPurposeCodes = getInitialReadingPurposeCodes(nextReadingPurposes, myPage);
         const initialBookIds = getInitialBookIds(nextBooks, myPage);
 
         if (!ignore) {
           setAvailableCategories(nextCategories);
           setAvailableBooks(nextBooks);
+          setAvailableReadingPurposes(nextReadingPurposes);
           setSelectedCategoryIds(initialCategoryIds);
+          setSelectedReadingPurposeCodes(initialReadingPurposeCodes);
           setSelectedBookIds(initialBookIds);
-          setIsEditMode(initialCategoryIds.length > 0 || initialBookIds.length > 0);
-          setCanSave(nextCategories.length > 0);
-          if (nextCategories.length === 0) {
+          setIsEditMode(initialCategoryIds.length > 0 || initialReadingPurposeCodes.length > 0 || initialBookIds.length > 0);
+          setCanSave(nextCategories.length > 0 && nextReadingPurposes.length > 0);
+          if (nextCategories.length === 0 || nextReadingPurposes.length === 0) {
             setMessage("온보딩 선택지가 아직 준비되지 않았습니다. 잠시 후 다시 시도해 주세요.");
           }
         }
@@ -127,6 +154,7 @@ export default function OnboardingPage() {
         if (!ignore) {
           setAvailableCategories([]);
           setAvailableBooks([]);
+          setAvailableReadingPurposes([]);
           setIsEditMode(false);
           setCanSave(false);
           setMessage("온보딩 선택지를 불러오지 못했습니다. 잠시 후 다시 시도해 주세요.");
@@ -157,6 +185,20 @@ export default function OnboardingPage() {
     setErrorMessage("");
   }
 
+  function toggleReadingPurpose(purposeCode) {
+    setSelectedReadingPurposeCodes((current) => {
+      if (current.includes(purposeCode)) {
+        return current.filter((code) => code !== purposeCode);
+      }
+      if (current.length >= 3) {
+        setErrorMessage("독서 목적은 최대 3개까지 선택할 수 있습니다.");
+        return current;
+      }
+      setErrorMessage("");
+      return [...current, purposeCode];
+    });
+  }
+
   async function submitOnboarding(event) {
     event.preventDefault();
 
@@ -167,6 +209,11 @@ export default function OnboardingPage() {
 
     if (!canSave) {
       setErrorMessage("온보딩 선택지를 불러온 뒤 저장할 수 있습니다.");
+      return;
+    }
+
+    if (selectedReadingPurposeCodes.length === 0) {
+      setErrorMessage("독서 목적을 1개 이상 선택해 주세요.");
       return;
     }
 
@@ -184,6 +231,7 @@ export default function OnboardingPage() {
           body: JSON.stringify({
             categoryIds: selectedCategoryIds,
             readBookIds: selectedBookIds,
+            readingPurposeCodes: selectedReadingPurposeCodes,
           }),
           headers: {
             Authorization: `Bearer ${accessToken}`,
@@ -218,7 +266,7 @@ export default function OnboardingPage() {
           <div className="rounded-lg border border-[#E5E7EB] bg-white p-6 shadow-sm">
             <p className="text-sm font-semibold text-[#4CAF50]">{isEditMode ? "취향 수정" : "개인화 시작"}</p>
             <h1 className="mt-3 text-3xl font-bold leading-tight text-[#1E2A38]">
-              {isEditMode ? "관심 분야와 읽은 책을 다시 조정해 주세요" : "관심 분야와 읽은 책을 선택해 주세요"}
+              {isEditMode ? "관심 분야, 독서 목적, 읽은 책을 다시 조정해 주세요" : "관심 분야, 독서 목적, 읽은 책을 선택해 주세요"}
             </h1>
             <p className="mt-4 max-w-2xl text-sm leading-6 text-[#6B7280]">
               {isEditMode
@@ -267,6 +315,49 @@ export default function OnboardingPage() {
               }) : (
                 <p className="rounded-lg border border-[#E5E7EB] bg-[#F5F3EF] p-4 text-sm text-[#6B7280] md:col-span-2 xl:col-span-3">
                   선택 가능한 관심 분야를 불러오지 못했습니다.
+                </p>
+              )}
+            </div>
+          </section>
+
+          <section
+            className={`rounded-lg border bg-white p-5 shadow-sm ${
+              isPurposeFocused ? "border-[#2563EB] ring-2 ring-[#2563EB]/20" : "border-[#E5E7EB]"
+            }`}
+          >
+            <div className="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
+              <div>
+                <p className="text-sm font-semibold text-[#1E2A38]">독서 목적</p>
+                <h2 className="mt-2 text-2xl font-bold text-[#1E2A38]">책을 찾는 이유</h2>
+                {isPurposeFocused ? <p className="mt-2 text-sm text-[#2563EB]">마이페이지에서 독서 목적 수정을 선택했습니다.</p> : null}
+              </div>
+              <span className="rounded-full bg-[#2563EB]/10 px-3 py-2 text-xs font-semibold text-[#1D4ED8]">
+                {selectedReadingPurposeCodes.length}/3개 선택
+              </span>
+            </div>
+
+            <div className="mt-5 grid grid-cols-1 gap-3 md:grid-cols-2 xl:grid-cols-3">
+              {availableReadingPurposes.length > 0 ? availableReadingPurposes.map((purpose) => {
+                const isSelected = selectedReadingPurposeCodes.includes(purpose.code);
+
+                return (
+                  <button
+                    className={`rounded-lg border p-4 text-left transition ${
+                      isSelected
+                        ? "border-[#2563EB] bg-[#2563EB]/10"
+                        : "border-[#E5E7EB] bg-white hover:border-[#1E2A38]"
+                    }`}
+                    key={purpose.code}
+                    type="button"
+                    onClick={() => toggleReadingPurpose(purpose.code)}
+                  >
+                    <span className="text-base font-bold text-[#1E2A38]">{purpose.label}</span>
+                    <span className="mt-2 block text-sm leading-6 text-[#6B7280]">{purpose.description}</span>
+                  </button>
+                );
+              }) : (
+                <p className="rounded-lg border border-[#E5E7EB] bg-[#F5F3EF] p-4 text-sm text-[#6B7280] md:col-span-2 xl:col-span-3">
+                  선택 가능한 독서 목적을 불러오지 못했습니다.
                 </p>
               )}
             </div>
@@ -349,6 +440,21 @@ export default function OnboardingPage() {
                   selectedSummary.categories.map((category) => (
                     <span className="rounded-full bg-[#4CAF50]/10 px-3 py-1 text-xs font-semibold text-[#4CAF50]" key={category.id}>
                       {category.name}
+                    </span>
+                  ))
+                ) : (
+                  <span className="text-sm text-[#6B7280]">아직 선택하지 않았습니다.</span>
+                )}
+              </div>
+            </div>
+
+            <div>
+              <p className="text-xs font-semibold text-[#6B7280]">독서 목적</p>
+              <div className="mt-2 flex flex-wrap gap-2">
+                {selectedSummary.readingPurposes.length > 0 ? (
+                  selectedSummary.readingPurposes.map((purpose) => (
+                    <span className="rounded-full bg-[#2563EB]/10 px-3 py-1 text-xs font-semibold text-[#1D4ED8]" key={purpose.code}>
+                      {purpose.label}
                     </span>
                   ))
                 ) : (


### PR DESCRIPTION
## 📌 개요
> 어떤 변경 사항인지

- 독서 목적 저장/조회 기능 추가
- 독서 목적을 개인화 추천 점수와 추천 이유에 반영
- 추천 히스토리 시간 컬럼명을 `generated_at`에서 `created_at`으로 통일

---

## 🔗 관련 이슈
- Closes #이슈번호

---

## ✨ 작업 내용
> 주요 변경 사항

### 🔹 Backend
- 독서 목적 enum 및 응답 DTO 추가
- 온보딩 선택지 API에 독서 목적 후보 추가
- 온보딩 저장 요청에 `readingPurposeCodes` 추가
- `user_reading_purposes` 기반 독서 목적 저장/조회 로직 추가
- 마이페이지 응답에 현재 독서 목적 목록 추가
- 개인화 추천 로직에 독서 목적 기반 카테고리/키워드 점수 반영
- 추천 reason에 독서 목적 기반 문구 반영
- 추천 히스토리 컬럼/응답 필드명을 `created_at` / `createdAt` 기준으로 통일
- 관련 controller/service 테스트 보강

### 🔹 Frontend
- 온보딩 화면에 독서 목적 1~3개 선택 UI 추가
- 온보딩 저장 요청에 `readingPurposeCodes` 연동
- 마이페이지에 독서 목적 요약 섹션 추가
- 독서 목적 수정 진입 링크 추가
- 추천 히스토리 날짜 표시 필드를 `createdAt`으로 변경
- 홈 추천 설명 문구에 독서 목적 반영

### 🔹 Docs
- `docs/mysql-ddl.sql`의 `recommendations.generated_at`을 `created_at`으로 변경
- 관련 계획 문서의 필드명 표현을 `createdAt` 기준으로 정리

---

## 🧪 테스트 결과
- [x] 로컬 테스트 완료
- [x] API 정상 동작 확인
- [x] 에러 케이스 확인

검증 명령:

- Backend: `.\gradlew.bat test` 성공
- Frontend: `npm run build` 성공

---

## 📸 스크린샷 (선택)
> UI 변경 시 첨부

- 온보딩 독서 목적 선택 UI
- 마이페이지 독서 목적 요약 섹션

---

## ⚠️ 주의사항
- 운영 DB에 `user_reading_purposes` 테이블이 먼저 생성되어 있어야 함
- `recommendations.generated_at`을 `created_at`으로 변경하는 DB 쿼리 실행 필요
- 추천 히스토리 API 응답 필드가 `generatedAt`에서 `createdAt`으로 변경됨
- 독서 목적 기반 추천 매핑은 초기 규칙 기반이므로 추후 사용자 행동 데이터로 가중치 조정 필요

DB 변경 쿼리:

```sql
ALTER TABLE recommendations
  CHANGE COLUMN generated_at created_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6);
```

## 🚀 배포 전 체크리스트
- [x] 빌드 성공 (`npm run build`, `.\gradlew.bat test`)
- [ ] 환경변수 설정 확인
- [x] DB 영향 여부 확인
- [ ] 운영 DB `user_reading_purposes` 테이블 존재 확인
- [ ] 운영 DB `recommendations.created_at` 컬럼 변경 확인

---

## 💬 리뷰 포인트
> 리뷰어가 집중해서 봐야 할 부분

- 독서 목적 코드/문구 분리 방식
- 온보딩 저장 시 기존 독서 목적 교체 저장 로직
- 독서 목적 1~3개 선택 제한 처리
- 개인화 추천 점수에서 독서 목적 가중치가 과하지 않은지
- 추천 reason이 255자 제한 안에서 자연스럽게 유지되는지
- `generated_at` → `created_at` 변경에 따른 API/DB 호환성
