### PR TITLE
feat: 데이터 기반 추천 확장(Closes #32)

### DIFF
--- a/backend/src/main/java/com/example/chaeklist/domain/book/controller/BookController.java
+++ b/backend/src/main/java/com/example/chaeklist/domain/book/controller/BookController.java
@@ -8,6 +8,7 @@ import com.example.chaeklist.domain.book.dto.BookDetailResponse;
 import com.example.chaeklist.domain.book.dto.BookImageEnrichmentResponse;
 import com.example.chaeklist.domain.book.dto.BookSummaryResponse;
 import com.example.chaeklist.domain.book.dto.HomeResponse;
+import com.example.chaeklist.domain.book.dto.KeywordTrendResponse;
 import com.example.chaeklist.domain.book.service.BookImageEnrichmentService;
 import com.example.chaeklist.domain.book.service.BookService;
 import com.example.chaeklist.global.auth.AuthenticatedUser;
@@ -92,6 +93,16 @@ public class BookController {
 			@Parameter(description = "반환 개수. 최대 50", example = "10") @RequestParam(defaultValue = "10") int limit
 	) {
 		return bookService.getTrending(limit);
+	}
+
+	@GetMapping("/api/books/trends/keywords")
+	@Operation(summary = "키워드 트렌드 조회", description = "교양 필터를 통과한 책의 키워드별 트렌드와 대표 도서를 반환합니다.")
+	@ApiResponse(responseCode = "200", description = "키워드 트렌드 조회 성공")
+	public List<KeywordTrendResponse> keywordTrends(
+			@Parameter(description = "반환할 키워드 개수. 최대 20", example = "3") @RequestParam(defaultValue = "3") int limit,
+			@Parameter(description = "키워드별 대표 도서 개수. 최대 10", example = "3") @RequestParam(defaultValue = "3") int booksPerKeyword
+	) {
+		return bookService.getKeywordTrends(limit, booksPerKeyword);
 	}
 
 	@GetMapping("/api/books/categories")

--- a/backend/src/main/java/com/example/chaeklist/domain/book/dto/KeywordTrendResponse.java
+++ b/backend/src/main/java/com/example/chaeklist/domain/book/dto/KeywordTrendResponse.java
@@ -1,0 +1,18 @@
+package com.example.chaeklist.domain.book.dto;
+
+import java.util.List;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "키워드 기반 트렌드 응답")
+public record KeywordTrendResponse(
+		@Schema(description = "트렌드 키워드", example = "투자")
+		String keyword,
+		@Schema(description = "키워드에 연결된 교양 도서 수", example = "12")
+		int bookCount,
+		@Schema(description = "키워드 트렌드 점수 표시값", example = "+18%")
+		String trendScore,
+		@Schema(description = "키워드와 연결된 대표 도서")
+		List<BookSummaryResponse> books
+) {
+}

--- a/backend/src/main/java/com/example/chaeklist/domain/book/repository/BookRepository.java
+++ b/backend/src/main/java/com/example/chaeklist/domain/book/repository/BookRepository.java
@@ -29,4 +29,30 @@ public interface BookRepository extends JpaRepository<Book, Long> {
 				)
 			""")
 	List<Book> searchGeneralEligibleByTitleOrAuthor(@Param("query") String query, Pageable pageable);
+
+	@Query("""
+			SELECT b
+			FROM Book b
+			JOIN b.keywords keyword
+			LEFT JOIN BookRankingSnapshot snapshot
+				ON snapshot.book = b
+				AND snapshot.category IS NULL
+				AND snapshot.rankingPeriod = :period
+				AND snapshot.rankDate = (
+					SELECT MAX(latest.rankDate)
+					FROM BookRankingSnapshot latest
+					WHERE latest.category IS NULL
+						AND latest.rankingPeriod = :period
+				)
+			WHERE b.generalEligible = TRUE
+				AND keyword.name = :keyword
+			ORDER BY COALESCE(snapshot.recentGrowthRate, 0) DESC,
+				COALESCE(snapshot.rankingScore, 0) DESC,
+				b.id DESC
+			""")
+	List<Book> findTrendingBooksByKeyword(
+			@Param("keyword") String keyword,
+			@Param("period") String period,
+			Pageable pageable
+	);
 }

--- a/backend/src/main/java/com/example/chaeklist/domain/book/repository/BookRepository.java
+++ b/backend/src/main/java/com/example/chaeklist/domain/book/repository/BookRepository.java
@@ -46,6 +46,7 @@ public interface BookRepository extends JpaRepository<Book, Long> {
 				)
 			WHERE b.generalEligible = TRUE
 				AND keyword.name = :keyword
+				AND keyword.keywordType = 'TREND'
 			ORDER BY COALESCE(snapshot.recentGrowthRate, 0) DESC,
 				COALESCE(snapshot.rankingScore, 0) DESC,
 				b.id DESC

--- a/backend/src/main/java/com/example/chaeklist/domain/book/service/BookImagePredeployRunner.java
+++ b/backend/src/main/java/com/example/chaeklist/domain/book/service/BookImagePredeployRunner.java
@@ -28,10 +28,6 @@ public class BookImagePredeployRunner implements ApplicationRunner {
 		if (seededCoverUrls > 0) {
 			log.info("Seed book cover URLs applied. updated={}", seededCoverUrls);
 		}
-		int seededKeywordMappings = applySeedKeywordMappings();
-		if (seededKeywordMappings > 0) {
-			log.info("Seed book keyword mappings applied. inserted={}", seededKeywordMappings);
-		}
 
 		try {
 			BookImageEnrichmentResponse response = bookImageEnrichmentService.enrichMissingCoverImages(PREDEPLOY_LIMIT);
@@ -70,48 +66,5 @@ public class BookImagePredeployRunner implements ApplicationRunner {
 					AND source_provider IN ('LOCAL', 'DUMMY')
 					AND (cover_image_url IS NULL OR cover_image_url = '')
 				""", coverImageUrl, sourceBookId);
-	}
-
-	private int applySeedKeywordMappings() {
-		int inserted = 0;
-		inserted += insertSeedKeywordMapping("dummy-sapiens", "역사");
-		inserted += insertSeedKeywordMapping("dummy-sapiens", "문명");
-		inserted += insertSeedKeywordMapping("dummy-money-psychology", "투자");
-		inserted += insertSeedKeywordMapping("dummy-money-psychology", "경제");
-		inserted += insertSeedKeywordMapping("dummy-atomic-habits", "습관");
-		inserted += insertSeedKeywordMapping("dummy-atomic-habits", "자기관리");
-		inserted += insertSeedKeywordMapping("dummy-human-acts", "소설");
-		inserted += insertSeedKeywordMapping("dummy-human-acts", "역사");
-		inserted += insertSeedKeywordMapping("dummy-why-fish", "과학");
-		inserted += insertSeedKeywordMapping("dummy-why-fish", "에세이");
-		inserted += insertSeedKeywordMapping("slow-reading", "독서");
-		inserted += insertSeedKeywordMapping("slow-reading", "집중");
-		inserted += insertSeedKeywordMapping("quiet-investing", "투자");
-		inserted += insertSeedKeywordMapping("quiet-investing", "경제");
-		inserted += insertSeedKeywordMapping("attention-design", "집중");
-		inserted += insertSeedKeywordMapping("attention-design", "도파민");
-		inserted += insertSeedKeywordMapping("small-city", "소설");
-		inserted += insertSeedKeywordMapping("small-city", "관계");
-		inserted += insertSeedKeywordMapping("daily-sentence", "문장");
-		inserted += insertSeedKeywordMapping("daily-sentence", "에세이");
-		return inserted;
-	}
-
-	private int insertSeedKeywordMapping(String sourceBookId, String keywordName) {
-		jdbcTemplate.update("""
-				INSERT INTO keywords (name, keyword_type, created_at)
-				VALUES (?, 'TREND', CURRENT_TIMESTAMP)
-				ON DUPLICATE KEY UPDATE name = VALUES(name)
-				""", keywordName);
-		return jdbcTemplate.update("""
-				INSERT IGNORE INTO book_keywords (book_id, keyword_id)
-				SELECT b.id, k.id
-				FROM books b
-				JOIN keywords k ON k.name = ?
-					AND k.keyword_type = 'TREND'
-				WHERE b.source_book_id = ?
-					AND b.source_provider IN ('LOCAL', 'DUMMY')
-					AND b.is_general_eligible = TRUE
-				""", keywordName, sourceBookId);
 	}
 }

--- a/backend/src/main/java/com/example/chaeklist/domain/book/service/BookImagePredeployRunner.java
+++ b/backend/src/main/java/com/example/chaeklist/domain/book/service/BookImagePredeployRunner.java
@@ -28,6 +28,10 @@ public class BookImagePredeployRunner implements ApplicationRunner {
 		if (seededCoverUrls > 0) {
 			log.info("Seed book cover URLs applied. updated={}", seededCoverUrls);
 		}
+		int seededKeywordMappings = applySeedKeywordMappings();
+		if (seededKeywordMappings > 0) {
+			log.info("Seed book keyword mappings applied. inserted={}", seededKeywordMappings);
+		}
 
 		try {
 			BookImageEnrichmentResponse response = bookImageEnrichmentService.enrichMissingCoverImages(PREDEPLOY_LIMIT);
@@ -66,5 +70,48 @@ public class BookImagePredeployRunner implements ApplicationRunner {
 					AND source_provider IN ('LOCAL', 'DUMMY')
 					AND (cover_image_url IS NULL OR cover_image_url = '')
 				""", coverImageUrl, sourceBookId);
+	}
+
+	private int applySeedKeywordMappings() {
+		int inserted = 0;
+		inserted += insertSeedKeywordMapping("dummy-sapiens", "역사");
+		inserted += insertSeedKeywordMapping("dummy-sapiens", "문명");
+		inserted += insertSeedKeywordMapping("dummy-money-psychology", "투자");
+		inserted += insertSeedKeywordMapping("dummy-money-psychology", "경제");
+		inserted += insertSeedKeywordMapping("dummy-atomic-habits", "습관");
+		inserted += insertSeedKeywordMapping("dummy-atomic-habits", "자기관리");
+		inserted += insertSeedKeywordMapping("dummy-human-acts", "소설");
+		inserted += insertSeedKeywordMapping("dummy-human-acts", "역사");
+		inserted += insertSeedKeywordMapping("dummy-why-fish", "과학");
+		inserted += insertSeedKeywordMapping("dummy-why-fish", "에세이");
+		inserted += insertSeedKeywordMapping("slow-reading", "독서");
+		inserted += insertSeedKeywordMapping("slow-reading", "집중");
+		inserted += insertSeedKeywordMapping("quiet-investing", "투자");
+		inserted += insertSeedKeywordMapping("quiet-investing", "경제");
+		inserted += insertSeedKeywordMapping("attention-design", "집중");
+		inserted += insertSeedKeywordMapping("attention-design", "도파민");
+		inserted += insertSeedKeywordMapping("small-city", "소설");
+		inserted += insertSeedKeywordMapping("small-city", "관계");
+		inserted += insertSeedKeywordMapping("daily-sentence", "문장");
+		inserted += insertSeedKeywordMapping("daily-sentence", "에세이");
+		return inserted;
+	}
+
+	private int insertSeedKeywordMapping(String sourceBookId, String keywordName) {
+		jdbcTemplate.update("""
+				INSERT INTO keywords (name, keyword_type, created_at)
+				VALUES (?, 'TREND', CURRENT_TIMESTAMP)
+				ON DUPLICATE KEY UPDATE name = VALUES(name)
+				""", keywordName);
+		return jdbcTemplate.update("""
+				INSERT IGNORE INTO book_keywords (book_id, keyword_id)
+				SELECT b.id, k.id
+				FROM books b
+				JOIN keywords k ON k.name = ?
+					AND k.keyword_type = 'TREND'
+				WHERE b.source_book_id = ?
+					AND b.source_provider IN ('LOCAL', 'DUMMY')
+					AND b.is_general_eligible = TRUE
+				""", keywordName, sourceBookId);
 	}
 }

--- a/backend/src/main/java/com/example/chaeklist/domain/book/service/BookSeedKeywordRunner.java
+++ b/backend/src/main/java/com/example/chaeklist/domain/book/service/BookSeedKeywordRunner.java
@@ -1,0 +1,79 @@
+package com.example.chaeklist.domain.book.service;
+
+import java.util.List;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+public class BookSeedKeywordRunner implements ApplicationRunner {
+
+	private static final Logger log = LoggerFactory.getLogger(BookSeedKeywordRunner.class);
+	private static final List<SeedKeywordMapping> SEED_KEYWORD_MAPPINGS = List.of(
+			new SeedKeywordMapping("dummy-sapiens", "역사"),
+			new SeedKeywordMapping("dummy-sapiens", "문명"),
+			new SeedKeywordMapping("dummy-money-psychology", "투자"),
+			new SeedKeywordMapping("dummy-money-psychology", "경제"),
+			new SeedKeywordMapping("dummy-atomic-habits", "습관"),
+			new SeedKeywordMapping("dummy-atomic-habits", "자기관리"),
+			new SeedKeywordMapping("dummy-human-acts", "소설"),
+			new SeedKeywordMapping("dummy-human-acts", "역사"),
+			new SeedKeywordMapping("dummy-why-fish", "과학"),
+			new SeedKeywordMapping("dummy-why-fish", "에세이"),
+			new SeedKeywordMapping("slow-reading", "독서"),
+			new SeedKeywordMapping("slow-reading", "집중"),
+			new SeedKeywordMapping("quiet-investing", "투자"),
+			new SeedKeywordMapping("quiet-investing", "경제"),
+			new SeedKeywordMapping("attention-design", "집중"),
+			new SeedKeywordMapping("attention-design", "도파민"),
+			new SeedKeywordMapping("small-city", "소설"),
+			new SeedKeywordMapping("small-city", "관계"),
+			new SeedKeywordMapping("daily-sentence", "문장"),
+			new SeedKeywordMapping("daily-sentence", "에세이")
+	);
+
+	private final JdbcTemplate jdbcTemplate;
+
+	public BookSeedKeywordRunner(JdbcTemplate jdbcTemplate) {
+		this.jdbcTemplate = jdbcTemplate;
+	}
+
+	@Override
+	public void run(ApplicationArguments args) {
+		int inserted = applySeedKeywordMappings();
+		if (inserted > 0) {
+			log.info("Seed book keyword mappings applied. inserted={}", inserted);
+		}
+	}
+
+	private int applySeedKeywordMappings() {
+		return SEED_KEYWORD_MAPPINGS.stream()
+				.mapToInt(this::insertSeedKeywordMapping)
+				.sum();
+	}
+
+	private int insertSeedKeywordMapping(SeedKeywordMapping mapping) {
+		jdbcTemplate.update("""
+				INSERT INTO keywords (name, keyword_type, created_at)
+				VALUES (?, 'TREND', CURRENT_TIMESTAMP)
+				ON DUPLICATE KEY UPDATE name = VALUES(name)
+				""", mapping.keywordName());
+		return jdbcTemplate.update("""
+				INSERT IGNORE INTO book_keywords (book_id, keyword_id)
+				SELECT b.id, k.id
+				FROM books b
+				JOIN keywords k ON k.name = ?
+					AND k.keyword_type = 'TREND'
+				WHERE b.source_book_id = ?
+					AND b.source_provider IN ('LOCAL', 'DUMMY')
+					AND b.is_general_eligible = TRUE
+				""", mapping.keywordName(), mapping.sourceBookId());
+	}
+
+	private record SeedKeywordMapping(String sourceBookId, String keywordName) {
+	}
+}

--- a/backend/src/main/java/com/example/chaeklist/domain/book/service/BookService.java
+++ b/backend/src/main/java/com/example/chaeklist/domain/book/service/BookService.java
@@ -132,6 +132,7 @@ public class BookService {
 							AND snapshot.ranking_period = ?
 					)
 				WHERE b.is_general_eligible = TRUE
+					AND k.keyword_type = 'TREND'
 				GROUP BY k.id, k.name
 				ORDER BY trend_score DESC, book_count DESC, k.name ASC
 				LIMIT ?

--- a/backend/src/main/java/com/example/chaeklist/domain/book/service/BookService.java
+++ b/backend/src/main/java/com/example/chaeklist/domain/book/service/BookService.java
@@ -1,5 +1,6 @@
 package com.example.chaeklist.domain.book.service;
 
+import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashSet;
@@ -14,6 +15,7 @@ import com.example.chaeklist.domain.book.dto.BookDetailResponse.RecommendationEv
 import com.example.chaeklist.domain.book.dto.BookSummaryResponse;
 import com.example.chaeklist.domain.book.dto.CategoryRankingResponse;
 import com.example.chaeklist.domain.book.dto.HomeResponse;
+import com.example.chaeklist.domain.book.dto.KeywordTrendResponse;
 import com.example.chaeklist.domain.book.entity.Book;
 import com.example.chaeklist.domain.book.entity.BookRankingSnapshot;
 import com.example.chaeklist.domain.book.repository.BookRankingSnapshotRepository;
@@ -37,6 +39,10 @@ public class BookService {
 	private static final int SEARCH_DEFAULT_LIMIT = 10;
 	private static final int SEARCH_MAX_LIMIT = 20;
 	private static final int SEARCH_MIN_QUERY_LENGTH = 2;
+	private static final int KEYWORD_TREND_DEFAULT_LIMIT = 3;
+	private static final int KEYWORD_TREND_MAX_LIMIT = 20;
+	private static final int KEYWORD_TREND_BOOK_DEFAULT_LIMIT = 3;
+	private static final int KEYWORD_TREND_BOOK_MAX_LIMIT = 10;
 	private static final String FALLBACK_RECOMMENDATION_REASON = "랭킹 지표와 교양 필터링 기준을 반영한 책입니다.";
 
 	private final BookRepository bookRepository;
@@ -99,6 +105,58 @@ public class BookService {
 		String normalizedQuery = normalizeSearchQuery(query);
 		return bookRepository.searchGeneralEligibleByTitleOrAuthor(normalizedQuery, pageById(normalizeSearchLimit(limit))).stream()
 				.map(BookSummaryResponse::from)
+				.toList();
+	}
+
+	public List<KeywordTrendResponse> getKeywordTrends(int limit, int booksPerKeyword) {
+		int normalizedLimit = normalizeKeywordTrendLimit(limit);
+		int normalizedBooksPerKeyword = normalizeKeywordTrendBookLimit(booksPerKeyword);
+		String period = normalizePeriod("weekly");
+
+		return jdbcTemplate.query("""
+				SELECT
+					k.name AS keyword_name,
+					COUNT(DISTINCT b.id) AS book_count,
+					COALESCE(MAX(latest_snapshot.recent_growth_rate), 0) AS trend_score
+				FROM keywords k
+				JOIN book_keywords bk ON bk.keyword_id = k.id
+				JOIN books b ON b.id = bk.book_id
+				LEFT JOIN book_ranking_snapshots latest_snapshot
+					ON latest_snapshot.book_id = b.id
+					AND latest_snapshot.category_id IS NULL
+					AND latest_snapshot.ranking_period = ?
+					AND latest_snapshot.rank_date = (
+						SELECT MAX(snapshot.rank_date)
+						FROM book_ranking_snapshots snapshot
+						WHERE snapshot.category_id IS NULL
+							AND snapshot.ranking_period = ?
+					)
+				WHERE b.is_general_eligible = TRUE
+				GROUP BY k.id, k.name
+				ORDER BY trend_score DESC, book_count DESC, k.name ASC
+				LIMIT ?
+				""",
+				(resultSet, rowNumber) -> new KeywordTrend(
+						resultSet.getString("keyword_name"),
+						resultSet.getInt("book_count"),
+						resultSet.getBigDecimal("trend_score")
+				),
+				period,
+				period,
+				normalizedLimit
+		).stream()
+				.map(keywordTrend -> new KeywordTrendResponse(
+						keywordTrend.keyword(),
+						keywordTrend.bookCount(),
+						formatTrendScore(keywordTrend.trendScore()),
+						bookRepository.findTrendingBooksByKeyword(
+										keywordTrend.keyword(),
+										period,
+										pageById(normalizedBooksPerKeyword)
+								).stream()
+								.map(BookSummaryResponse::from)
+								.toList()
+				))
 				.toList();
 	}
 
@@ -586,6 +644,24 @@ public class BookService {
 		return Math.min(limit, SEARCH_MAX_LIMIT);
 	}
 
+	private int normalizeKeywordTrendLimit(int limit) {
+		if (limit <= 0) {
+			return KEYWORD_TREND_DEFAULT_LIMIT;
+		}
+		return Math.min(limit, KEYWORD_TREND_MAX_LIMIT);
+	}
+
+	private int normalizeKeywordTrendBookLimit(int limit) {
+		if (limit <= 0) {
+			return KEYWORD_TREND_BOOK_DEFAULT_LIMIT;
+		}
+		return Math.min(limit, KEYWORD_TREND_BOOK_MAX_LIMIT);
+	}
+
+	private String formatTrendScore(BigDecimal score) {
+		return "%+.0f%%".formatted(score == null ? 0 : score.doubleValue());
+	}
+
 	private String normalizeSearchQuery(String query) {
 		if (query == null || query.trim().length() < SEARCH_MIN_QUERY_LENGTH) {
 			throw new BookRequestException("Search query must be at least 2 characters.");
@@ -636,5 +712,8 @@ public class BookService {
 	}
 
 	private record PersonalizedRecommendation(Book book, String reason, int score) {
+	}
+
+	private record KeywordTrend(String keyword, int bookCount, BigDecimal trendScore) {
 	}
 }

--- a/backend/src/test/java/com/example/chaeklist/BookControllerTest.java
+++ b/backend/src/test/java/com/example/chaeklist/BookControllerTest.java
@@ -149,6 +149,30 @@ class BookControllerTest {
 	}
 
 	@Test
+	@Transactional
+	void excludesNonTrendKeywordsFromKeywordTrends() throws Exception {
+		insertCategory(641, "경제");
+		insertKeyword(651, "투자");
+		insertKeywordWithType(652, "기출", "EXCLUDE");
+		insertBook(661, "투자 트렌드 책", true);
+		insertBook(662, "기출 키워드가 붙은 교양 책", true);
+		insertBookCategory(661, 641);
+		insertBookCategory(662, 641);
+		insertBookKeyword(661, 651);
+		insertBookKeyword(662, 652);
+		insertRankingSnapshot(671, 661, null, 1);
+		insertRankingSnapshot(672, 662, null, 2);
+
+		mockMvc.perform(get("/api/books/trends/keywords")
+						.param("limit", "5")
+						.param("booksPerKeyword", "2"))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$[?(@.keyword == '투자')]", hasSize(1)))
+				.andExpect(jsonPath("$[?(@.keyword == '기출')]", hasSize(0)))
+				.andExpect(jsonPath("$[0].books[?(@.id == '662')]", hasSize(0)));
+	}
+
+	@Test
 	void returnsEmptyKeywordTrends() throws Exception {
 		mockMvc.perform(get("/api/books/trends/keywords"))
 				.andExpect(status().isOk())
@@ -625,10 +649,14 @@ class BookControllerTest {
 	}
 
 	private void insertKeyword(long id, String name) {
+		insertKeywordWithType(id, name, "TREND");
+	}
+
+	private void insertKeywordWithType(long id, String name, String keywordType) {
 		jdbcTemplate.update("""
 				INSERT INTO keywords (id, name, keyword_type, created_at)
-				VALUES (?, ?, 'GENERAL', CURRENT_TIMESTAMP)
-				""", id, name);
+				VALUES (?, ?, ?, CURRENT_TIMESTAMP)
+				""", id, name, keywordType);
 	}
 
 	private void insertBook(long id, String title, boolean generalEligible) {

--- a/backend/src/test/java/com/example/chaeklist/BookControllerTest.java
+++ b/backend/src/test/java/com/example/chaeklist/BookControllerTest.java
@@ -116,6 +116,46 @@ class BookControllerTest {
 	}
 
 	@Test
+	@Transactional
+	void returnsKeywordTrendsWithRepresentativeBooks() throws Exception {
+		insertCategory(601, "경제");
+		insertKeyword(611, "투자");
+		insertKeyword(612, "AI");
+		insertBook(621, "투자 대표 책", true);
+		insertBook(622, "AI 대표 책", true);
+		insertBook(623, "제외될 수험서", false);
+		insertBookCategory(621, 601);
+		insertBookCategory(622, 601);
+		insertBookCategory(623, 601);
+		insertBookKeyword(621, 611);
+		insertBookKeyword(622, 612);
+		insertBookKeyword(623, 611);
+		insertRankingSnapshot(631, 621, null, 2);
+		insertRankingSnapshot(632, 622, null, 1);
+
+		mockMvc.perform(get("/api/books/trends/keywords")
+						.param("limit", "2")
+						.param("booksPerKeyword", "1"))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$", hasSize(2)))
+				.andExpect(jsonPath("$[0].keyword", is("AI")))
+				.andExpect(jsonPath("$[0].bookCount", is(1)))
+				.andExpect(jsonPath("$[0].trendScore", is("+15%")))
+				.andExpect(jsonPath("$[0].books", hasSize(1)))
+				.andExpect(jsonPath("$[0].books[0].id", is("622")))
+				.andExpect(jsonPath("$[1].keyword", is("투자")))
+				.andExpect(jsonPath("$[1].bookCount", is(1)))
+				.andExpect(jsonPath("$[1].books[?(@.id == '623')]", hasSize(0)));
+	}
+
+	@Test
+	void returnsEmptyKeywordTrends() throws Exception {
+		mockMvc.perform(get("/api/books/trends/keywords"))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$", hasSize(0)));
+	}
+
+	@Test
 	void returnsCategories() throws Exception {
 		mockMvc.perform(get("/api/books/categories"))
 				.andExpect(status().isOk())

--- a/backend/src/test/java/com/example/chaeklist/BookControllerTest.java
+++ b/backend/src/test/java/com/example/chaeklist/BookControllerTest.java
@@ -173,6 +173,32 @@ class BookControllerTest {
 	}
 
 	@Test
+	@Transactional
+	void usesOnlyTrendKeywordWhenSameKeywordNameHasDifferentTypes() throws Exception {
+		insertCategory(681, "경제");
+		insertKeywordWithType(691, "투자", "TREND");
+		insertKeywordWithType(692, "투자", "GENERAL");
+		insertBook(701, "트렌드 투자 책", true);
+		insertBook(702, "일반 투자 키워드 책", true);
+		insertBookCategory(701, 681);
+		insertBookCategory(702, 681);
+		insertBookKeyword(701, 691);
+		insertBookKeyword(702, 692);
+		insertRankingSnapshot(711, 701, null, 1);
+		insertRankingSnapshot(712, 702, null, 2);
+
+		mockMvc.perform(get("/api/books/trends/keywords")
+						.param("limit", "5")
+						.param("booksPerKeyword", "5"))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$[?(@.keyword == '투자')]", hasSize(1)))
+				.andExpect(jsonPath("$[0].keyword", is("투자")))
+				.andExpect(jsonPath("$[0].bookCount", is(1)))
+				.andExpect(jsonPath("$[0].books[?(@.id == '701')]", hasSize(1)))
+				.andExpect(jsonPath("$[0].books[?(@.id == '702')]", hasSize(0)));
+	}
+
+	@Test
 	void returnsEmptyKeywordTrends() throws Exception {
 		mockMvc.perform(get("/api/books/trends/keywords"))
 				.andExpect(status().isOk())

--- a/frontend/src/data/books.js
+++ b/frontend/src/data/books.js
@@ -83,3 +83,24 @@ export const categoryRankings = categories
     category,
     books: books.filter((book) => book.category === category),
   }));
+
+export const keywordTrends = [
+  {
+    keyword: "투자",
+    bookCount: 1,
+    trendScore: "+24%",
+    books: [books[1]],
+  },
+  {
+    keyword: "집중",
+    bookCount: 2,
+    trendScore: "+31%",
+    books: [books[2], books[0]],
+  },
+  {
+    keyword: "문장",
+    bookCount: 1,
+    trendScore: "+11%",
+    books: [books[4]],
+  },
+];

--- a/frontend/src/pages/CategoriesPage.jsx
+++ b/frontend/src/pages/CategoriesPage.jsx
@@ -1,7 +1,84 @@
+import { useEffect, useState } from "react";
 import BookCard from "../components/BookCard";
-import { categoryRankings } from "../data/books";
+import { categoryRankings as fallbackCategoryRankings } from "../data/books";
+
+function normalizeBook(book) {
+  return {
+    ...book,
+    growth: book.growth ?? book.growthRate,
+    reason: book.reason ?? book.recommendationReason,
+  };
+}
+
+function normalizeGroup(group) {
+  return {
+    ...group,
+    books: (group.books ?? []).map(normalizeBook),
+  };
+}
 
 export default function CategoriesPage() {
+  const [categoryRankings, setCategoryRankings] = useState(fallbackCategoryRankings.map(normalizeGroup));
+  const [status, setStatus] = useState("loading");
+  const [errorMessage, setErrorMessage] = useState("");
+
+  useEffect(() => {
+    let ignore = false;
+
+    async function loadCategoryRankings() {
+      setStatus("loading");
+      setErrorMessage("");
+
+      try {
+        const categoriesResponse = await fetch("/api/books/categories");
+
+        if (!categoriesResponse.ok) {
+          throw new Error("카테고리 목록을 불러오지 못했습니다.");
+        }
+
+        const categories = await categoriesResponse.json();
+        const groups = await Promise.all(
+          (Array.isArray(categories) ? categories : []).map(async (category) => {
+            const params = new URLSearchParams({
+              period: "weekly",
+              limit: "6",
+            });
+            const response = await fetch(`/api/books/categories/${encodeURIComponent(category)}/rankings?${params.toString()}`);
+
+            if (!response.ok) {
+              throw new Error("카테고리 랭킹을 불러오지 못했습니다.");
+            }
+
+            const books = await response.json();
+            return {
+              category,
+              books: (Array.isArray(books) ? books : []).map(normalizeBook),
+            };
+          }),
+        );
+
+        if (!ignore) {
+          setCategoryRankings(groups);
+          setStatus("ready");
+        }
+      } catch (error) {
+        if (!ignore) {
+          setCategoryRankings(fallbackCategoryRankings.map(normalizeGroup));
+          setErrorMessage(error instanceof Error ? error.message : "카테고리 데이터를 불러오지 못했습니다.");
+          setStatus("fallback");
+        }
+      }
+    }
+
+    loadCategoryRankings();
+
+    return () => {
+      ignore = true;
+    };
+  }, []);
+
+  const isLoading = status === "loading";
+
   return (
     <section className="mx-auto w-full max-w-7xl px-5 py-8">
       <div className="rounded-lg border border-[#E5E7EB] bg-white p-5 shadow-sm">
@@ -12,18 +89,51 @@ export default function CategoriesPage() {
         </p>
       </div>
 
-      <div className="mt-6 space-y-6">
-        {categoryRankings.map((group) => (
-          <section className="rounded-lg border border-[#E5E7EB] bg-white p-5 shadow-sm" key={group.category}>
-            <h2 className="text-xl font-bold text-[#1E2A38]">{group.category}</h2>
-            <div className="mt-4 grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">
-              {group.books.map((book, index) => (
-                <BookCard book={book} key={book.id} rank={index + 1} />
-              ))}
-            </div>
-          </section>
-        ))}
-      </div>
+      {errorMessage ? (
+        <div className="mt-5 rounded-lg border border-[#E5E7EB] bg-white px-4 py-3 text-sm text-[#6B7280] shadow-sm">
+          API 응답을 받지 못해 임시 데이터를 표시합니다. {errorMessage}
+        </div>
+      ) : null}
+
+      {isLoading ? (
+        <div className="mt-6 rounded-lg border border-[#E5E7EB] bg-white p-5 text-sm text-[#6B7280] shadow-sm">
+          카테고리 랭킹을 불러오는 중입니다.
+        </div>
+      ) : null}
+
+      {!isLoading && categoryRankings.length === 0 ? (
+        <div className="mt-6 rounded-lg border border-[#E5E7EB] bg-white p-8 text-center shadow-sm">
+          <p className="text-base font-bold text-[#1E2A38]">표시할 카테고리 랭킹이 없습니다</p>
+          <p className="mt-2 text-sm text-[#6B7280]">활성 카테고리와 랭킹 데이터가 준비되면 이곳에 표시합니다.</p>
+        </div>
+      ) : null}
+
+      {!isLoading && categoryRankings.length > 0 ? (
+        <div className="mt-6 space-y-6">
+          {categoryRankings.map((group) => (
+            <section className="rounded-lg border border-[#E5E7EB] bg-white p-5 shadow-sm" key={group.category}>
+              <div className="flex flex-col gap-1 sm:flex-row sm:items-end sm:justify-between">
+                <div>
+                  <p className="text-sm font-semibold text-[#4CAF50]">{group.category}</p>
+                  <h2 className="text-xl font-bold text-[#1E2A38]">{group.category} 분야 TOP 도서</h2>
+                </div>
+                <p className="text-sm text-[#6B7280]">주간 랭킹 기준</p>
+              </div>
+              {group.books.length ? (
+                <div className="mt-4 grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">
+                  {group.books.map((book, index) => (
+                    <BookCard book={book} key={book.id} rank={book.rankPosition ?? index + 1} />
+                  ))}
+                </div>
+              ) : (
+                <p className="mt-4 rounded-lg border border-[#E5E7EB] p-4 text-sm text-[#6B7280]">
+                  이 분야의 랭킹 데이터가 아직 없습니다.
+                </p>
+              )}
+            </section>
+          ))}
+        </div>
+      ) : null}
     </section>
   );
 }

--- a/frontend/src/pages/HomePage.jsx
+++ b/frontend/src/pages/HomePage.jsx
@@ -2,7 +2,7 @@ import { useEffect, useMemo, useState } from "react";
 import { Link } from "react-router-dom";
 import { useAuth } from "../App";
 import BookCard from "../components/BookCard";
-import { books, categoryRankings, trendingBooks } from "../data/books";
+import { books, categoryRankings, keywordTrends as fallbackKeywordTrends, trendingBooks } from "../data/books";
 
 const coverPalette = {
   경제: "bg-[#4CAF50]",
@@ -53,11 +53,20 @@ function normalizeHomeResponse(data, fallbackHome) {
   };
 }
 
+function normalizeKeywordTrend(trend) {
+  return {
+    ...trend,
+    books: (trend.books ?? []).map(withDisplayDefaults),
+  };
+}
+
 export default function HomePage() {
   const { accessToken, currentUser, isAuthReady, logout } = useAuth();
   const fallbackHome = useMemo(() => createFallbackHome(currentUser), [currentUser]);
   const [home, setHome] = useState(fallbackHome);
+  const [keywordTrends, setKeywordTrends] = useState(fallbackKeywordTrends.map(normalizeKeywordTrend));
   const [status, setStatus] = useState("loading");
+  const [trendStatus, setTrendStatus] = useState("loading");
   const [notice, setNotice] = useState("");
 
   useEffect(() => {
@@ -111,8 +120,46 @@ export default function HomePage() {
     };
   }, [accessToken, currentUser, fallbackHome, isAuthReady, logout]);
 
+  useEffect(() => {
+    let ignore = false;
+
+    async function loadKeywordTrends() {
+      setTrendStatus("loading");
+
+      try {
+        const params = new URLSearchParams({
+          limit: "3",
+          booksPerKeyword: "2",
+        });
+        const response = await fetch(`/api/books/trends/keywords?${params.toString()}`);
+
+        if (!response.ok) {
+          throw new Error("키워드 트렌드를 불러오지 못했습니다.");
+        }
+
+        const data = await response.json();
+        if (!ignore) {
+          setKeywordTrends((Array.isArray(data) ? data : []).map(normalizeKeywordTrend));
+          setTrendStatus("ready");
+        }
+      } catch {
+        if (!ignore) {
+          setKeywordTrends(fallbackKeywordTrends.map(normalizeKeywordTrend));
+          setTrendStatus("fallback");
+        }
+      }
+    }
+
+    loadKeywordTrends();
+
+    return () => {
+      ignore = true;
+    };
+  }, []);
+
   const recommendation = home.todayRecommendation;
   const isLoading = status === "loading";
+  const isTrendLoading = trendStatus === "loading";
 
   return (
     <div className="mx-auto w-full max-w-7xl px-5 py-8 lg:py-10">
@@ -240,6 +287,60 @@ export default function HomePage() {
             )
           )}
         </div>
+      </section>
+
+      <section className="mt-8 rounded-lg border border-[#E5E7EB] bg-white p-5 shadow-sm">
+        <div className="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
+          <div>
+            <p className="text-sm font-semibold text-[#4CAF50]">키워드 트렌드</p>
+            <h2 className="mt-2 text-2xl font-bold text-[#1E2A38]">요즘 함께 읽히는 주제</h2>
+          </div>
+          <Link className="text-sm font-semibold text-[#1E2A38] hover:underline" to="/categories">
+            분야별로 더 보기
+          </Link>
+        </div>
+
+        {isTrendLoading ? (
+          <p className="mt-5 rounded-lg border border-[#E5E7EB] p-4 text-sm text-[#6B7280]">
+            키워드 트렌드를 불러오는 중입니다.
+          </p>
+        ) : null}
+
+        {!isTrendLoading && keywordTrends.length === 0 ? (
+          <p className="mt-5 rounded-lg border border-[#E5E7EB] p-4 text-sm text-[#6B7280]">
+            아직 키워드 트렌드 데이터가 없습니다.
+          </p>
+        ) : null}
+
+        {!isTrendLoading && keywordTrends.length > 0 ? (
+          <div className="mt-5 grid grid-cols-1 gap-4 lg:grid-cols-3">
+            {keywordTrends.map((trend) => (
+              <article className="rounded-lg border border-[#E5E7EB] p-4" key={trend.keyword}>
+                <div className="flex items-start justify-between gap-3">
+                  <div>
+                    <p className="text-xs font-semibold text-[#6B7280]">#{trend.keyword}</p>
+                    <h3 className="mt-1 text-lg font-bold text-[#1E2A38]">{trend.bookCount}권이 연결된 주제</h3>
+                  </div>
+                  <span className="rounded-full bg-[#F59E0B]/10 px-2 py-1 text-xs font-bold text-[#F59E0B]">
+                    {trend.trendScore}
+                  </span>
+                </div>
+                <div className="mt-4 space-y-3">
+                  {trend.books.slice(0, 2).map((book) => (
+                    <Link
+                      className="block rounded-md border border-[#E5E7EB] p-3 transition hover:border-[#1E2A38]"
+                      key={book.id}
+                      to={`/books/${book.id}`}
+                    >
+                      <p className="line-clamp-1 text-sm font-bold text-[#1E2A38]">{book.title}</p>
+                      <p className="mt-1 text-xs text-[#6B7280]">{book.author}</p>
+                    </Link>
+                  ))}
+                </div>
+              </article>
+            ))}
+          </div>
+        ) : null}
       </section>
     </div>
   );

--- a/frontend/src/pages/HomePage.jsx
+++ b/frontend/src/pages/HomePage.jsx
@@ -306,6 +306,12 @@ export default function HomePage() {
           </p>
         ) : null}
 
+        {trendStatus === "fallback" ? (
+          <p className="mt-5 rounded-lg border border-[#E5E7EB] bg-[#F5F3EF] p-4 text-sm text-[#6B7280]">
+            API 응답을 받지 못해 임시 키워드 트렌드를 표시합니다.
+          </p>
+        ) : null}
+
         {!isTrendLoading && keywordTrends.length === 0 ? (
           <p className="mt-5 rounded-lg border border-[#E5E7EB] p-4 text-sm text-[#6B7280]">
             아직 키워드 트렌드 데이터가 없습니다.


### PR DESCRIPTION
## 📌 개요
> 어떤 변경 사항인지

- README 기준 트렌드 피드 강화를 위해 키워드 트렌드 API와 화면 연동을 구현
- 카테고리 페이지를 실제 랭킹 API 기반으로 전환
- seed 도서의 키워드 매핑을 자동 보정하도록 backend runner 추가
- 키워드 타입 필터링 및 회귀 테스트 보강

---

## 🔗 관련 이슈
- Closes #32 

---

## ✨ 작업 내용
> 주요 변경 사항

### 🔹 Backend
- 키워드 트렌드 조회 API 구현
  - `GET /api/books/trends/keywords`
  - `limit`, `booksPerKeyword` 파라미터 지원
  - 교양 도서(`is_general_eligible = TRUE`) 기준으로 키워드별 트렌드와 대표 도서 반환
- 키워드 트렌드 집계 시 `TREND` 타입 키워드만 포함하도록 필터링
- 대표 도서 조회 시 동일한 키워드명이라도 `TREND` 타입 매핑만 사용하도록 수정
- seed 도서 키워드 매핑 자동 보정 runner 추가
  - `BookSeedKeywordRunner`
  - seed 책과 `TREND` 키워드 매핑을 서버 시작 시 보정
- 기존 `BookImagePredeployRunner`에서 키워드 seed 보정 책임 제거
  - 이미지 보정과 키워드 seed 보정 책임 분리
- 키워드 트렌드 관련 테스트 추가
  - 정상 키워드 트렌드 응답
  - `EXCLUDE` 키워드 제외
  - 동일 키워드명에서 `TREND` / `GENERAL` 타입이 공존할 때 `TREND`만 사용

### 🔹 Frontend
- 홈 화면에 키워드 트렌드 섹션 추가
  - `/api/books/trends/keywords` API 연동
  - 키워드별 연결 도서 수, 트렌드 점수, 대표 도서 표시
- 키워드 트렌드 API 실패 시 fallback 데이터 표시
- API 실패 fallback 상태에서 안내 문구 표시
  - “API 응답을 받지 못해 임시 키워드 트렌드를 표시합니다.”
- 카테고리 페이지 API 연동
  - `/api/books/categories`
  - `/api/books/categories/{category}/rankings`
- 카테고리 페이지 로딩, 빈 데이터, API 실패 fallback 상태 처리
- fallback 데이터에 키워드 트렌드 샘플 추가

---

## 🧪 테스트 결과
- [x] 로컬 테스트 완료
- [x] API 정상 동작 확인
- [x] 에러 케이스 확인

### Backend
- [x] `.\gradlew.bat test` 성공
- [x] 키워드 트렌드 API 응답 확인
- [x] `EXCLUDE`, `GENERAL` 키워드가 트렌드 응답에 섞이지 않는 테스트 확인

### Frontend
- [x] `npm run build` 성공
- [x] 홈 키워드 트렌드 섹션 빌드 확인
- [x] 카테고리 페이지 API 연동 빌드 확인
- [x] 키워드 트렌드 API 실패 시 fallback 안내 문구 표시 로직 확인

---

## 📸 스크린샷 (선택)
> UI 변경 시 첨부

- 홈 화면 키워드 트렌드 섹션
- 카테고리별 랭킹 페이지

---

## ⚠️ 주의사항
- 키워드 트렌드 API는 현재 `WEEKLY` 랭킹 snapshot 기준으로 동작
- seed 키워드 매핑은 `source_book_id`가 `LOCAL` 또는 `DUMMY`인 seed 도서를 기준으로 보정
- 로컬 DB에 `book_keywords` 매핑이 없으면 서버 재시작 시 `BookSeedKeywordRunner`가 보정
- API 실패 시 frontend는 빈 화면 대신 fallback 키워드 트렌드를 표시
- PowerShell에서 API 응답 한글이 깨져 보일 수 있으나 브라우저 응답 자체의 문제는 아님

---

## 🚀 배포 전 체크리스트
- [x] 빌드 성공 (`npm run build`)
- [x] 테스트 성공 (`.\gradlew.bat test`)
- [ ] 환경변수 설정 확인
- [x] DB 영향 여부 확인
- [ ] 운영 DB seed 도서의 `source_book_id`, `source_provider` 값 확인
- [ ] 운영 DB에 `keywords`, `book_keywords` 테이블 및 제약 조건 확인
- [ ] backend 서버 재시작 후 seed keyword runner 정상 로그 확인

---

## 💬 리뷰 포인트
> 리뷰어가 집중해서 봐야 할 부분

- 키워드 트렌드 집계 쿼리에서 `TREND` 타입만 포함하는 방식
- 동일 키워드명에 여러 `keyword_type`이 있을 때 대표 도서 조회가 올바른지
- `BookSeedKeywordRunner`의 seed 매핑 목록과 책임 분리 방식
- 홈 키워드 트렌드 fallback UX가 적절한지
- 카테고리 페이지에서 여러 카테고리 랭킹 API를 병렬 호출하는 방식
