### PR TITLE
fix: 홈 화면 주요 콘텐츠 정상 표시(Closes #41)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,6 +73,7 @@
 - All responses must be written in Korean.
 - Use clear and concise Korean explanations.
 - Keep technical terms in English only when necessary.
+- 문서와 계획 파일도 사용자가 다른 언어를 명시적으로 요청하지 않는 한 한국어로 작성한다.
 
 ## Output rules
 - Summarize:

--- a/backend/src/main/java/com/example/chaeklist/domain/book/controller/BookController.java
+++ b/backend/src/main/java/com/example/chaeklist/domain/book/controller/BookController.java
@@ -149,7 +149,7 @@ public class BookController {
 	}
 
 	@PostMapping("/api/books/images/enrich")
-	@Operation(summary = "책 표지 이미지 일괄 보강", description = "cover_image_url이 비어 있는 책을 Kakao 도서 검색 API로 보강합니다.")
+	@Operation(summary = "책 표지 이미지 일괄 보강", description = "cover_image_url이 비어 있거나 local seed asset인 책을 Kakao 도서 검색 API로 보강합니다.")
 	@ApiResponse(responseCode = "200", description = "이미지 보강 실행 완료")
 	@ApiResponse(responseCode = "401", description = "실행 키 누락 또는 불일치")
 	@ApiResponse(responseCode = "503", description = "이미지 보강 설정 누락")

--- a/backend/src/main/java/com/example/chaeklist/domain/book/dto/BookImageEnrichmentResponse.java
+++ b/backend/src/main/java/com/example/chaeklist/domain/book/dto/BookImageEnrichmentResponse.java
@@ -1,5 +1,7 @@
 package com.example.chaeklist.domain.book.dto;
 
+import java.util.List;
+
 import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(description = "책 표지 이미지 보강 결과")
@@ -8,9 +10,25 @@ public record BookImageEnrichmentResponse(
 		int processed,
 		@Schema(description = "이미지 URL 저장 성공 수", example = "15")
 		int updated,
-		@Schema(description = "검색 결과가 없거나 매칭 실패한 수", example = "4")
+		@Schema(description = "검색 결과나 thumbnail이 없어 건너뛴 수", example = "4")
 		int skipped,
 		@Schema(description = "외부 API 호출 또는 저장 실패 수", example = "1")
-		int failed
+		int failed,
+		List<ItemResult> items
 ) {
+
+	public BookImageEnrichmentResponse(int processed, int updated, int skipped, int failed) {
+		this(processed, updated, skipped, failed, List.of());
+	}
+
+	public record ItemResult(
+			String bookId,
+			String title,
+			String author,
+			String status,
+			String reason,
+			List<String> queries,
+			String imageUrl
+	) {
+	}
 }

--- a/backend/src/main/java/com/example/chaeklist/domain/book/service/BookImageEnrichmentService.java
+++ b/backend/src/main/java/com/example/chaeklist/domain/book/service/BookImageEnrichmentService.java
@@ -6,6 +6,7 @@ import java.util.Objects;
 import java.util.Optional;
 
 import com.example.chaeklist.domain.book.dto.BookImageEnrichmentResponse;
+import com.example.chaeklist.domain.book.dto.BookImageEnrichmentResponse.ItemResult;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Service;
@@ -44,21 +45,28 @@ public class BookImageEnrichmentService {
 		int updated = 0;
 		int skipped = 0;
 		int failed = 0;
+		java.util.ArrayList<ItemResult> items = new java.util.ArrayList<>();
 
 		for (BookImageTarget target : targets) {
 			try {
-				Optional<String> imageUrl = searchCoverImageUrl(target);
-				if (imageUrl.isEmpty()) {
+				SearchResult searchResult = searchCoverImageUrl(target);
+				if (searchResult.imageUrl().isEmpty()) {
 					skipped++;
+					items.add(toItemResult(target, "SKIPPED", searchResult.reason(), searchResult.queries(), null));
 					continue;
 				}
-				updated += updateCoverImageUrl(target.id(), imageUrl.get());
+				int updateCount = updateCoverImageUrl(target.id(), searchResult.imageUrl().get());
+				updated += updateCount;
+				items.add(toItemResult(target, updateCount > 0 ? "UPDATED" : "SKIPPED",
+						updateCount > 0 ? "UPDATED_WITH_KAKAO_THUMBNAIL" : "COVER_URL_NOT_UPDATABLE",
+						searchResult.queries(), searchResult.imageUrl().get()));
 			} catch (RestClientException exception) {
 				failed++;
+				items.add(toItemResult(target, "FAILED", exception.getClass().getSimpleName(), List.of(searchQuery(target)), null));
 			}
 		}
 
-		return new BookImageEnrichmentResponse(targets.size(), updated, skipped, failed);
+		return new BookImageEnrichmentResponse(targets.size(), updated, skipped, failed, items);
 	}
 
 	private List<BookImageTarget> findTargets(int limit) {
@@ -66,7 +74,7 @@ public class BookImageEnrichmentService {
 				SELECT id, title, author, isbn13
 				FROM books
 				WHERE is_general_eligible = TRUE
-					AND (cover_image_url IS NULL OR cover_image_url = '')
+					AND (cover_image_url IS NULL OR cover_image_url = '' OR cover_image_url LIKE '/book-covers/%')
 				ORDER BY id ASC
 				LIMIT ?
 				""",
@@ -80,10 +88,25 @@ public class BookImageEnrichmentService {
 		);
 	}
 
-	private Optional<String> searchCoverImageUrl(BookImageTarget target) {
+	private SearchResult searchCoverImageUrl(BookImageTarget target) {
+		java.util.ArrayList<String> queries = new java.util.ArrayList<>();
+		for (String query : searchQueries(target)) {
+			if (query.isBlank() || queries.contains(query)) {
+				continue;
+			}
+			queries.add(query);
+			Optional<String> imageUrl = searchCoverImageUrl(query, target);
+			if (imageUrl.isPresent()) {
+				return new SearchResult(imageUrl, queries, "FOUND_KAKAO_THUMBNAIL");
+			}
+		}
+		return new SearchResult(Optional.empty(), queries, "NO_KAKAO_THUMBNAIL");
+	}
+
+	private Optional<String> searchCoverImageUrl(String query, BookImageTarget target) {
 		KakaoBookSearchResponse response = restClient.get()
 				.uri(kakaoBookSearchUrl, uriBuilder -> uriBuilder
-						.queryParam("query", searchQuery(target))
+						.queryParam("query", query)
 						.queryParam("size", 10)
 						.build())
 				.header("Authorization", "KakaoAK " + kakaoApiKey)
@@ -101,10 +124,21 @@ public class BookImageEnrichmentService {
 				.findFirst();
 	}
 
+	private List<String> searchQueries(BookImageTarget target) {
+		if (target.isbn13() != null && !target.isbn13().isBlank()) {
+			return List.of(target.isbn13(), titleAuthorQuery(target), target.title());
+		}
+		return List.of(titleAuthorQuery(target), target.title());
+	}
+
 	private String searchQuery(BookImageTarget target) {
 		if (target.isbn13() != null && !target.isbn13().isBlank()) {
 			return target.isbn13();
 		}
+		return titleAuthorQuery(target);
+	}
+
+	private String titleAuthorQuery(BookImageTarget target) {
 		return target.title() + " " + target.author();
 	}
 
@@ -115,7 +149,7 @@ public class BookImageEnrichmentService {
 					source_provider = COALESCE(NULLIF(source_provider, ''), 'KAKAO'),
 					updated_at = CURRENT_TIMESTAMP
 				WHERE id = ?
-					AND (cover_image_url IS NULL OR cover_image_url = '')
+					AND (cover_image_url IS NULL OR cover_image_url = '' OR cover_image_url LIKE '/book-covers/%')
 				""", imageUrl, bookId);
 	}
 
@@ -152,6 +186,16 @@ public class BookImageEnrichmentService {
 		return Math.min(limit, MAX_LIMIT);
 	}
 
+	private ItemResult toItemResult(
+			BookImageTarget target,
+			String status,
+			String reason,
+			List<String> queries,
+			String imageUrl
+	) {
+		return new ItemResult(String.valueOf(target.id()), target.title(), target.author(), status, reason, queries, imageUrl);
+	}
+
 	public static class BookImageEnrichmentException extends RuntimeException {
 
 		public BookImageEnrichmentException(String message) {
@@ -160,6 +204,9 @@ public class BookImageEnrichmentService {
 	}
 
 	private record BookImageTarget(long id, String title, String author, String isbn13) {
+	}
+
+	private record SearchResult(Optional<String> imageUrl, List<String> queries, String reason) {
 	}
 
 	private record KakaoBookSearchResponse(List<KakaoBookDocument> documents) {

--- a/backend/src/main/java/com/example/chaeklist/domain/book/service/BookImagePredeployRunner.java
+++ b/backend/src/main/java/com/example/chaeklist/domain/book/service/BookImagePredeployRunner.java
@@ -5,10 +5,12 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.ApplicationArguments;
 import org.springframework.boot.ApplicationRunner;
+import org.springframework.core.annotation.Order;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Component;
 
 @Component
+@Order(1)
 public class BookImagePredeployRunner implements ApplicationRunner {
 
 	private static final Logger log = LoggerFactory.getLogger(BookImagePredeployRunner.class);
@@ -64,7 +66,7 @@ public class BookImagePredeployRunner implements ApplicationRunner {
 					updated_at = CURRENT_TIMESTAMP
 				WHERE source_book_id = ?
 					AND source_provider IN ('LOCAL', 'DUMMY')
-					AND (cover_image_url IS NULL OR cover_image_url = '')
+					AND (cover_image_url IS NULL OR cover_image_url = '' OR cover_image_url LIKE '%callback%')
 				""", coverImageUrl, sourceBookId);
 	}
 }

--- a/backend/src/main/java/com/example/chaeklist/domain/book/service/BookSeedMetadataRunner.java
+++ b/backend/src/main/java/com/example/chaeklist/domain/book/service/BookSeedMetadataRunner.java
@@ -1,0 +1,61 @@
+package com.example.chaeklist.domain.book.service;
+
+import java.util.List;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.core.annotation.Order;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+@Order(0)
+public class BookSeedMetadataRunner implements ApplicationRunner {
+
+	private static final Logger log = LoggerFactory.getLogger(BookSeedMetadataRunner.class);
+	private static final List<SeedBookMetadata> SEED_BOOKS = List.of(
+			new SeedBookMetadata("dummy-sapiens", "사피엔스", "유발 하라리", "김영사"),
+			new SeedBookMetadata("dummy-money-psychology", "돈의 심리학", "모건 하우절", "인플루엔셜"),
+			new SeedBookMetadata("dummy-atomic-habits", "아주 작은 습관의 힘", "제임스 클리어", "비즈니스북스"),
+			new SeedBookMetadata("dummy-human-acts", "소년이 온다", "한강", "창비"),
+			new SeedBookMetadata("dummy-why-fish", "물고기는 존재하지 않는다", "룰루 밀러", "곰출판"),
+			new SeedBookMetadata("slow-reading", "책은 도끼다", "박웅현", "북하우스"),
+			new SeedBookMetadata("quiet-investing", "돈의 심리학", "모건 하우절", "인플루엔셜"),
+			new SeedBookMetadata("attention-design", "아주 작은 습관의 힘", "제임스 클리어", "비즈니스북스"),
+			new SeedBookMetadata("small-city", "불편한 편의점", "김호연", "나무옆의자"),
+			new SeedBookMetadata("daily-sentence", "하루 한 장 나의 어휘력을 위한 필사 노트", "유선경", "위즈덤하우스")
+	);
+
+	private final JdbcTemplate jdbcTemplate;
+
+	public BookSeedMetadataRunner(JdbcTemplate jdbcTemplate) {
+		this.jdbcTemplate = jdbcTemplate;
+	}
+
+	@Override
+	public void run(ApplicationArguments args) {
+		int updated = SEED_BOOKS.stream()
+				.mapToInt(this::updateSeedBook)
+				.sum();
+		if (updated > 0) {
+			log.info("Seed book metadata applied. updated={}", updated);
+		}
+	}
+
+	private int updateSeedBook(SeedBookMetadata seedBook) {
+		return jdbcTemplate.update("""
+				UPDATE books
+				SET title = ?,
+					author = ?,
+					publisher = ?,
+					updated_at = CURRENT_TIMESTAMP
+				WHERE source_book_id = ?
+					AND source_provider IN ('LOCAL', 'DUMMY')
+				""", seedBook.title(), seedBook.author(), seedBook.publisher(), seedBook.sourceBookId());
+	}
+
+	private record SeedBookMetadata(String sourceBookId, String title, String author, String publisher) {
+	}
+}

--- a/backend/src/main/java/com/example/chaeklist/domain/mypage/service/MyPageService.java
+++ b/backend/src/main/java/com/example/chaeklist/domain/mypage/service/MyPageService.java
@@ -27,6 +27,7 @@ import com.example.chaeklist.domain.mypage.dto.ReadingGrowthResponse.Badge;
 import com.example.chaeklist.domain.mypage.dto.ReadingPurposeResponse;
 import com.example.chaeklist.domain.mypage.model.ReadingPurpose;
 import com.example.chaeklist.global.auth.AuthenticatedUser;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -38,9 +39,11 @@ public class MyPageService {
 	private static final Set<String> SUPPORTED_BOOK_INTERACTIONS = Set.of("SAVE", "UNSAVE", "READ", "DISMISS");
 
 	private final JdbcTemplate jdbcTemplate;
+	private final String readingGrowthToday;
 
-	public MyPageService(JdbcTemplate jdbcTemplate) {
+	public MyPageService(JdbcTemplate jdbcTemplate, @Value("${chaeklist.reading-growth.today:}") String readingGrowthToday) {
 		this.jdbcTemplate = jdbcTemplate;
+		this.readingGrowthToday = readingGrowthToday;
 	}
 
 	public MyPageResponse getMyPage(AuthenticatedUser user) {
@@ -562,7 +565,9 @@ public class MyPageService {
 	}
 
 	private ReadingGrowthMetrics getReadingGrowthMetrics(long userId) {
-		LocalDate today = LocalDate.now();
+		LocalDate today = readingGrowthToday == null || readingGrowthToday.isBlank()
+				? LocalDate.now()
+				: LocalDate.parse(readingGrowthToday);
 		LocalDateTime monthStart = today.withDayOfMonth(1).atStartOfDay();
 		LocalDateTime nextMonthStart = today.plusMonths(1).withDayOfMonth(1).atStartOfDay();
 		int monthlyReadCount = countMonthlyReadBooks(userId, monthStart, nextMonthStart);

--- a/backend/src/test/java/com/example/chaeklist/BookControllerTest.java
+++ b/backend/src/test/java/com/example/chaeklist/BookControllerTest.java
@@ -8,6 +8,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.example.chaeklist.domain.book.service.BookImagePredeployRunner;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
@@ -33,6 +34,9 @@ class BookControllerTest {
 
 	@Autowired
 	private JdbcTemplate jdbcTemplate;
+
+	@Autowired
+	private BookImagePredeployRunner bookImagePredeployRunner;
 
 	@Test
 	void returnsPublicHome() throws Exception {
@@ -258,6 +262,36 @@ class BookControllerTest {
 						.param("query", "없는검색어"))
 				.andExpect(status().isOk())
 				.andExpect(jsonPath("$", hasSize(0)));
+	}
+
+	@Test
+	@Transactional
+	void replacesCallbackStyleSeedCoverUrlWithLocalAsset() {
+		insertSeedBook(741, "Slow Reading", "slow-reading", "LOCAL", "https://example.com/book-cover/callback?id=slow-reading");
+
+		bookImagePredeployRunner.run(null);
+
+		String coverImageUrl = jdbcTemplate.queryForObject("""
+				SELECT cover_image_url
+				FROM books
+				WHERE id = ?
+				""", String.class, 741);
+		org.assertj.core.api.Assertions.assertThat(coverImageUrl).isEqualTo("/book-covers/slow-reading.svg");
+	}
+
+	@Test
+	@Transactional
+	void keepsKakaoSeedCoverUrlDuringPredeploy() {
+		insertSeedBook(742, "Slow Reading", "slow-reading", "LOCAL", "https://img.example.com/slow-reading.jpg");
+
+		bookImagePredeployRunner.run(null);
+
+		String coverImageUrl = jdbcTemplate.queryForObject("""
+				SELECT cover_image_url
+				FROM books
+				WHERE id = ?
+				""", String.class, 742);
+		org.assertj.core.api.Assertions.assertThat(coverImageUrl).isEqualTo("https://img.example.com/slow-reading.jpg");
 	}
 
 	@Test
@@ -701,6 +735,16 @@ class BookControllerTest {
 				)
 				VALUES (?, ?, ?, '상세 설명', ?, 'INCLUDED', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
 				""", id, title, author, generalEligible);
+	}
+
+	private void insertSeedBook(long id, String title, String sourceBookId, String sourceProvider, String coverImageUrl) {
+		jdbcTemplate.update("""
+				INSERT INTO books (
+					id, title, author, description, cover_image_url, source_provider, source_book_id,
+					is_general_eligible, filter_status, created_at, updated_at
+				)
+				VALUES (?, ?, '테스트 저자', '상세 설명', ?, ?, ?, TRUE, 'INCLUDED', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+				""", id, title, coverImageUrl, sourceProvider, sourceBookId);
 	}
 
 	private void insertBookCategory(long bookId, long categoryId) {

--- a/backend/src/test/java/com/example/chaeklist/BookImageEnrichmentServiceTest.java
+++ b/backend/src/test/java/com/example/chaeklist/BookImageEnrichmentServiceTest.java
@@ -1,0 +1,140 @@
+package com.example.chaeklist;
+
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.anything;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+import com.example.chaeklist.domain.book.dto.BookImageEnrichmentResponse;
+import com.example.chaeklist.domain.book.service.BookImageEnrichmentService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.JdbcTest;
+import org.springframework.http.MediaType;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestClient;
+
+@JdbcTest
+class BookImageEnrichmentServiceTest {
+
+	@Autowired
+	private JdbcTemplate jdbcTemplate;
+
+	@Test
+	void replacesLocalSeedAssetCoverWithKakaoThumbnail() {
+		createBooksTable();
+		insertBookWithLocalSeedCover();
+		RestClient.Builder restClientBuilder = RestClient.builder();
+		MockRestServiceServer server = MockRestServiceServer.bindTo(restClientBuilder).build();
+		BookImageEnrichmentService service = new BookImageEnrichmentService(
+				"test-kakao-key",
+				"https://kakao.test/search/book",
+				jdbcTemplate,
+				restClientBuilder
+		);
+		server.expect(anything())
+				.andRespond(withSuccess("""
+						{
+						  "documents": [
+						    {
+						      "title": "Slow Reading",
+						      "authors": ["Moon"],
+						      "thumbnail": "https://img.example.com/slow-reading.jpg"
+						    }
+						  ]
+						}
+						""", MediaType.APPLICATION_JSON));
+
+		BookImageEnrichmentResponse response = service.enrichMissingCoverImages(10);
+
+		String coverImageUrl = jdbcTemplate.queryForObject("""
+				SELECT cover_image_url
+				FROM books
+				WHERE id = ?
+				""", String.class, 1L);
+		org.assertj.core.api.Assertions.assertThat(response.processed()).isEqualTo(1);
+		org.assertj.core.api.Assertions.assertThat(response.updated()).isEqualTo(1);
+		org.assertj.core.api.Assertions.assertThat(coverImageUrl).isEqualTo("https://img.example.com/slow-reading.jpg");
+		server.verify();
+	}
+
+	@Test
+	void retriesWithTitleOnlyWhenTitleAuthorQueryHasNoThumbnail() {
+		createBooksTable();
+		insertBookWithLocalSeedCover();
+		RestClient.Builder restClientBuilder = RestClient.builder();
+		MockRestServiceServer server = MockRestServiceServer.bindTo(restClientBuilder).build();
+		BookImageEnrichmentService service = new BookImageEnrichmentService(
+				"test-kakao-key",
+				"https://kakao.test/search/book",
+				jdbcTemplate,
+				restClientBuilder
+		);
+		server.expect(anything())
+				.andRespond(withSuccess("""
+						{
+						  "documents": []
+						}
+						""", MediaType.APPLICATION_JSON));
+		server.expect(anything())
+				.andRespond(withSuccess("""
+						{
+						  "documents": [
+						    {
+						      "title": "Slow Reading",
+						      "authors": ["Moon"],
+						      "thumbnail": "https://img.example.com/title-only.jpg"
+						    }
+						  ]
+						}
+						""", MediaType.APPLICATION_JSON));
+
+		BookImageEnrichmentResponse response = service.enrichMissingCoverImages(10);
+
+		String coverImageUrl = jdbcTemplate.queryForObject("""
+				SELECT cover_image_url
+				FROM books
+				WHERE id = ?
+				""", String.class, 1L);
+		org.assertj.core.api.Assertions.assertThat(response.updated()).isEqualTo(1);
+		org.assertj.core.api.Assertions.assertThat(response.items().getFirst().queries())
+				.containsExactly("Slow Reading Moon", "Slow Reading");
+		org.assertj.core.api.Assertions.assertThat(coverImageUrl).isEqualTo("https://img.example.com/title-only.jpg");
+		server.verify();
+	}
+
+	private void createBooksTable() {
+		jdbcTemplate.execute("""
+				CREATE TABLE IF NOT EXISTS books (
+					id BIGINT PRIMARY KEY,
+					title VARCHAR(255) NOT NULL,
+					author VARCHAR(255) NOT NULL,
+					isbn13 VARCHAR(13),
+					cover_image_url VARCHAR(1000),
+					source_provider VARCHAR(50),
+					source_book_id VARCHAR(100),
+					is_general_eligible BOOLEAN NOT NULL,
+					updated_at TIMESTAMP NOT NULL
+				)
+				""");
+		jdbcTemplate.execute("ALTER TABLE books ADD COLUMN IF NOT EXISTS isbn13 VARCHAR(13)");
+		jdbcTemplate.execute("ALTER TABLE books ADD COLUMN IF NOT EXISTS cover_image_url VARCHAR(1000)");
+		jdbcTemplate.execute("ALTER TABLE books ADD COLUMN IF NOT EXISTS source_provider VARCHAR(50)");
+		jdbcTemplate.execute("ALTER TABLE books ADD COLUMN IF NOT EXISTS source_book_id VARCHAR(100)");
+		jdbcTemplate.execute("ALTER TABLE books ADD COLUMN IF NOT EXISTS is_general_eligible BOOLEAN");
+		jdbcTemplate.execute("ALTER TABLE books ADD COLUMN IF NOT EXISTS updated_at TIMESTAMP");
+	}
+
+	private void insertBookWithLocalSeedCover() {
+		jdbcTemplate.update("DELETE FROM books WHERE id = ?", 1L);
+		jdbcTemplate.update("""
+				INSERT INTO books (
+					id, title, author, cover_image_url, source_provider, source_book_id,
+					is_general_eligible, updated_at
+				)
+				VALUES (
+					1, 'Slow Reading', 'Moon', '/book-covers/slow-reading.svg', 'LOCAL',
+					'slow-reading', TRUE, CURRENT_TIMESTAMP
+				)
+				""");
+	}
+}

--- a/backend/src/test/java/com/example/chaeklist/BookSeedMetadataRunnerTest.java
+++ b/backend/src/test/java/com/example/chaeklist/BookSeedMetadataRunnerTest.java
@@ -1,0 +1,79 @@
+package com.example.chaeklist;
+
+import com.example.chaeklist.domain.book.service.BookSeedMetadataRunner;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.JdbcTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+@JdbcTest
+class BookSeedMetadataRunnerTest {
+
+	@Autowired
+	private JdbcTemplate jdbcTemplate;
+
+	@Test
+	void updatesLocalSeedBookToRealBookMetadata() {
+		createBooksTable();
+		insertLocalSeedBook();
+		BookSeedMetadataRunner runner = new BookSeedMetadataRunner(jdbcTemplate);
+
+		runner.run(null);
+
+		SeedBook seedBook = jdbcTemplate.queryForObject("""
+				SELECT title, author, publisher
+				FROM books
+				WHERE source_book_id = ?
+				""",
+				(resultSet, rowNumber) -> new SeedBook(
+						resultSet.getString("title"),
+						resultSet.getString("author"),
+						resultSet.getString("publisher")
+				),
+				"slow-reading"
+		);
+		org.assertj.core.api.Assertions.assertThat(seedBook)
+				.isEqualTo(new SeedBook("책은 도끼다", "박웅현", "북하우스"));
+	}
+
+	private void createBooksTable() {
+		jdbcTemplate.execute("""
+				CREATE TABLE IF NOT EXISTS books (
+					id BIGINT PRIMARY KEY,
+					title VARCHAR(255) NOT NULL,
+					author VARCHAR(255) NOT NULL,
+					publisher VARCHAR(100),
+					source_provider VARCHAR(50),
+					source_book_id VARCHAR(100),
+					is_general_eligible BOOLEAN NOT NULL,
+					filter_status VARCHAR(20) NOT NULL,
+					created_at TIMESTAMP NOT NULL,
+					updated_at TIMESTAMP NOT NULL
+				)
+				""");
+		jdbcTemplate.execute("ALTER TABLE books ADD COLUMN IF NOT EXISTS publisher VARCHAR(100)");
+		jdbcTemplate.execute("ALTER TABLE books ADD COLUMN IF NOT EXISTS source_provider VARCHAR(50)");
+		jdbcTemplate.execute("ALTER TABLE books ADD COLUMN IF NOT EXISTS source_book_id VARCHAR(100)");
+		jdbcTemplate.execute("ALTER TABLE books ADD COLUMN IF NOT EXISTS is_general_eligible BOOLEAN");
+		jdbcTemplate.execute("ALTER TABLE books ADD COLUMN IF NOT EXISTS filter_status VARCHAR(20)");
+		jdbcTemplate.execute("ALTER TABLE books ADD COLUMN IF NOT EXISTS created_at TIMESTAMP");
+		jdbcTemplate.execute("ALTER TABLE books ADD COLUMN IF NOT EXISTS updated_at TIMESTAMP");
+	}
+
+	private void insertLocalSeedBook() {
+		jdbcTemplate.update("DELETE FROM books WHERE id = ?", 1L);
+		jdbcTemplate.update("""
+				INSERT INTO books (
+					id, title, author, publisher, source_provider, source_book_id,
+					is_general_eligible, filter_status, created_at, updated_at
+				)
+				VALUES (
+					1, '느리게 읽는 힘', '문서윤', NULL, 'LOCAL', 'slow-reading',
+					TRUE, 'INCLUDED', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+				)
+				""");
+	}
+
+	private record SeedBook(String title, String author, String publisher) {
+	}
+}

--- a/backend/src/test/java/com/example/chaeklist/MyPageControllerTest.java
+++ b/backend/src/test/java/com/example/chaeklist/MyPageControllerTest.java
@@ -21,7 +21,7 @@ import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
 
-@SpringBootTest
+@SpringBootTest(properties = "chaeklist.reading-growth.today=2026-04-30")
 @AutoConfigureMockMvc
 @Transactional
 class MyPageControllerTest {

--- a/docs/plan/2026-05-03/seed-image-and-mypage-rendering-fix-plan.md
+++ b/docs/plan/2026-05-03/seed-image-and-mypage-rendering-fix-plan.md
@@ -1,0 +1,44 @@
+# Seed 이미지 및 MyPage 렌더링 문제 해결 계획
+
+## 문제
+
+Seed book cover 이미지가 callback 형식의 외부 이미지 URL로 표시되어 `frontend/public/book-covers`의 로컬 asset으로 우회했다. 이후 수동으로 수정했을 때 데이터 연동이 끊기고 MyPage 렌더링 오류가 발생했다.
+
+## 전제
+
+- seed cover의 목표 경로는 기존 public asset 경로 형식인 `/book-covers/{name}.svg`다.
+- 책 데이터의 기준은 backend이며, `cover_image_url`도 backend가 관리한다.
+- frontend는 기존 API 필드인 `imageUrl`을 사용하고, seed book 전용 매핑을 따로 들고 있지 않는다.
+- database schema, dependency, environment variable 변경은 계획하지 않는다.
+
+## 현재 파일 확인 결과
+
+- `backend/src/main/java/com/example/chaeklist/domain/book/service/BookImagePredeployRunner.java`는 알려진 seed `source_book_id`를 `/book-covers/*.svg`로 매핑한다. 다만 `cover_image_url`이 `NULL` 또는 빈 문자열일 때만 갱신한다.
+- `frontend/src/components/BookCard.jsx`는 `book.imageUrl`만 렌더링한다. backend 데이터가 이 계약과 다르게 바뀌면 표지가 일관되게 표시되지 않는다.
+- `backend/src/main/java/com/example/chaeklist/domain/mypage/dto/MyPageBookResponse.java`는 표지를 `imageUrl`로 노출하며, frontend 기대 필드와 일치한다.
+- `frontend/src/pages/MyPage.jsx`에는 여러 visible text와 prop 위치에 깨진 JSX/string literal이 있어, 데이터 문제와 별개로 render 또는 build 실패를 일으킬 수 있다.
+- 기존 backend test는 MyPage 데이터 형태와 interaction을 검증한다. seed cover 전파 로직을 바꾸면 관련 검증을 보강해야 한다.
+
+## 성공 기준
+
+- seed book이 API 응답에서 안정적인 local cover path를 `imageUrl`로 반환한다.
+- MyPage가 `/api/me/mypage`를 불러오고, JSX/runtime 오류 없이 렌더링된다.
+- read/saved/recommendation 데이터가 interaction 이후에도 MyPage에서 동기화된다.
+- 수동 database 수정은 불필요하거나, 기존의 잘못된 `cover_image_url` 보정으로만 제한된다.
+- frontend build가 통과한다.
+- backend logic을 변경한 경우 MyPage/book 관련 test가 통과한다.
+
+## 계획
+
+1. 오류 재현 및 범위 분리 -> verify: `frontend/`에서 `npm run build`를 실행해 MyPage syntax/render 오류를 정확히 확인한다.
+2. backend API 계약 확인 -> verify: `GET /api/me/mypage`와 book summary/detail 응답을 확인해 seed cover가 `coverImageUrl`이나 callback payload가 아니라 `imageUrl`로 내려오는지 검증한다.
+3. seed cover source 보수적 수정 -> verify: 필요한 경우 기존 seed cover URL 적용 조건만 조정해, 잘못된 callback-style URL이 들어간 알려진 seed row를 `/book-covers/*.svg`로 보정한다. book ID나 관계 table은 변경하지 않는다.
+4. MyPage 렌더링 복구 -> verify: `frontend/src/pages/MyPage.jsx`에서 깨진 JSX/text/prop literal만 수정하고, 기존 state 흐름과 API 호출은 유지한다.
+5. interaction 이후 데이터 연동 검증 -> verify: `POST /api/me/books/{bookId}/interactions` 이후 `GET /api/me/mypage`를 확인해 선택한 책이 `readBooks` 또는 `savedBooks`에 `imageUrl`과 함께 나타나는지 검증한다.
+6. 필수 검증 실행 -> verify: `frontend/`에서 `npm run build`를 실행한다. backend 변경이 있으면 `backend/`에서 `.\gradlew.bat test`를 실행한다.
+
+## 리스크
+
+- 수동 수정이 `cover_image_url`만이 아니라 `books.id`를 바꿨다면 `book_categories`, `user_book_interactions`, `recommendations` 같은 관계 table join이 깨졌을 수 있다. 이 경우 ID를 복구하고 `cover_image_url`만 갱신해야 한다.
+- 현재 seed runner는 빈 image field만 갱신하므로, 이미 callback-style URL이 들어간 row는 조건을 넓히지 않으면 자동 복구되지 않는다.
+- MyPage 파일은 JSX 손상뿐 아니라 text encoding 손상도 보인다. 가장 작은 수정은 build와 render에 필요한 깨진 literal/tag만 복구하는 것이다.


### PR DESCRIPTION
## 📌 개요
> 어떤 변경 사항인지

- seed 도서 이미지 보강 흐름 개선
- 가상 seed 도서 메타데이터를 실제 Kakao 도서 검색 가능한 도서 정보로 보정
- local asset 표지를 Kakao thumbnail로 교체할 수 있도록 이미지 보강 로직 개선
- MyPage 독서 성장 테스트의 날짜 의존성 제거

---

## 🔗 관련 이슈
- Closes #41 

---

## ✨ 작업 내용
> 주요 변경 사항

### 🔹 Backend
- `BookSeedMetadataRunner` 추가
  - 기존 `source_book_id`는 유지하면서 seed 도서의 `title`, `author`, `publisher`를 실제 도서 정보로 보정
- `BookImageEnrichmentService` 개선
  - `cover_image_url`이 비어 있는 책뿐 아니라 `/book-covers/%` local asset 경로도 Kakao 이미지 보강 대상으로 포함
  - Kakao 검색 fallback 추가: `ISBN13 -> 제목+저자 -> 제목`
  - 이미지 보강 응답에 책별 `status`, `reason`, `queries`, `imageUrl` 상세 결과 추가
- `BookImagePredeployRunner` 개선
  - callback 형식 URL 또는 빈 표지만 local asset fallback으로 보정
  - 이미 Kakao 이미지 URL이 들어간 경우 `/book-covers/*.svg`로 덮어쓰지 않도록 수정
- MyPage 독서 성장 계산 테스트 안정화
  - 테스트에서만 기준일을 고정할 수 있도록 `chaeklist.reading-growth.today` 설정 추가

### 🔹 Frontend
- 코드 변경 없음
- 기존 `imageUrl` 렌더링 흐름 유지

---

## 🧪 테스트 결과
- [x] 로컬 테스트 완료
- [x] API 정상 동작 확인
- [x] 에러 케이스 확인

---

## 📸 스크린샷 (선택)
> UI 변경 시 첨부

- UI 코드 변경 없음

---

## ⚠️ 주의사항
- 실제 Kakao thumbnail 보강을 위해 `KAKAO_REST_API_KEY` 설정 필요
- `/api/books/images/enrich` 실행을 위해 `BOOK_IMAGE_ENRICHMENT_KEY` 설정 필요
- seed 도서가 실제 Kakao 도서 검색 결과에 없는 경우 `skipped` 처리됨
- frontend에서 `ECONNREFUSED` 발생 시 로그인 문제가 아니라 backend 서버 미실행 또는 proxy target 포트 불일치 가능성 확인 필요

---

## 🚀 배포 전 체크리스트
- [x] 빌드 성공 (`npm run build`)
- [x] 테스트 성공 (`./gradlew test`)
- [ ] 환경변수 설정 확인
- [ ] DB 영향 여부 확인
- [ ] backend 재시작 후 `/api/books/images/enrich` 수동 실행 여부 확인

---

## 💬 리뷰 포인트
> 리뷰어가 집중해서 봐야 할 부분

- seed 도서 메타데이터를 runner에서 보정하는 방식이 적절한지
- Kakao 이미지 검색 fallback 순서가 적절한지
- local asset fallback과 Kakao thumbnail 보강이 서로 덮어쓰지 않도록 한 조건
- `BookImageEnrichmentResponse.items` 상세 응답 구조
- MyPage 테스트 기준일 주입 방식 (`chaeklist.reading-growth.today`)
