### PR TITLE
feat: 회원 탈퇴 구현(Closes #48)

### DIFF
--- a/backend/src/main/java/com/example/chaeklist/domain/auth/util/TokenService.java
+++ b/backend/src/main/java/com/example/chaeklist/domain/auth/util/TokenService.java
@@ -16,6 +16,8 @@ import javax.crypto.spec.SecretKeySpec;
 import com.example.chaeklist.domain.auth.dto.TokenPair;
 import com.example.chaeklist.domain.auth.entity.UserAccount;
 import com.example.chaeklist.global.auth.AuthenticatedUser;
+import org.springframework.dao.EmptyResultDataAccessException;
+import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -32,6 +34,11 @@ public class TokenService {
 
 	private final SecureRandom secureRandom = new SecureRandom();
 	private final byte[] signingKey = createSigningKey();
+	private final JdbcTemplate jdbcTemplate;
+
+	public TokenService(JdbcTemplate jdbcTemplate) {
+		this.jdbcTemplate = jdbcTemplate;
+	}
 
 	public TokenPair issueTokens(UserAccount user) {
 		return new TokenPair(
@@ -70,13 +77,32 @@ public class TokenService {
 			throw new TokenException("Access token expired.");
 		}
 
-		return new AuthenticatedUser(
-				Long.parseLong(claims.get("sub")),
-				claims.get("email"),
-				claims.get("nickname"),
-				claims.get("status"),
-				claims.get("role")
-		);
+		return findActiveUser(Long.parseLong(claims.get("sub")));
+	}
+
+	private AuthenticatedUser findActiveUser(long userId) {
+		try {
+			AuthenticatedUser user = jdbcTemplate.queryForObject("""
+					SELECT id, email, nickname, status, role
+					FROM users
+					WHERE id = ?
+					""",
+					(resultSet, rowNumber) -> new AuthenticatedUser(
+							resultSet.getLong("id"),
+							resultSet.getString("email"),
+							resultSet.getString("nickname"),
+							resultSet.getString("status"),
+							resultSet.getString("role")
+					),
+					userId
+			);
+			if (user == null || !"ACTIVE".equals(user.status())) {
+				throw new TokenException("Active account is required.");
+			}
+			return user;
+		} catch (EmptyResultDataAccessException exception) {
+			throw new TokenException("Active account is required.");
+		}
 	}
 
 	private String createToken(String type, UserAccount user, long expiresInSeconds) {

--- a/backend/src/test/java/com/example/chaeklist/SocialControllerTest.java
+++ b/backend/src/test/java/com/example/chaeklist/SocialControllerTest.java
@@ -1,5 +1,6 @@
 package com.example.chaeklist;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
@@ -368,6 +369,51 @@ class SocialControllerTest {
 						.param("query", "비활성화"))
 				.andExpect(status().isOk())
 				.andExpect(jsonPath("$", hasSize(0)));
+	}
+
+	@Test
+	@Transactional
+	void withdrawsUserAnonymizesPublicPostsAndRejectsExistingToken() throws Exception {
+		createSocialTables();
+		createUserPublicProfilesTable();
+		String accessToken = loginAndExtractAccessToken();
+		long userId = userId();
+		long postId = insertPublicTextPost(userId, "탈퇴 후에도 남을 공개 기록");
+		insertPublicProfile(userId);
+
+		mockMvc.perform(post("/api/me/withdraw")
+						.header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+				.andExpect(status().isNoContent());
+
+		UserWithdrawalRow userRow = jdbcTemplate.queryForObject("""
+				SELECT email, nickname, password_hash, status
+				FROM users
+				WHERE id = ?
+				""", (resultSet, rowNumber) -> new UserWithdrawalRow(
+						resultSet.getString("email"),
+						resultSet.getString("nickname"),
+						resultSet.getString("password_hash"),
+						resultSet.getString("status")
+				), userId);
+		assertThat(userRow.email()).isEqualTo("deleted_" + userId + "@deleted.local");
+		assertThat(userRow.nickname()).isEqualTo("deleted_" + userId);
+		assertThat(userRow.passwordHash()).isEmpty();
+		assertThat(userRow.status()).isEqualTo("DELETED");
+
+		mockMvc.perform(get("/api/social/feed"))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$", hasSize(1)))
+				.andExpect(jsonPath("$[0].id", is((int) postId)))
+				.andExpect(jsonPath("$[0].userId").doesNotExist())
+				.andExpect(jsonPath("$[0].nickname", is("탈퇴한 사용자")))
+				.andExpect(jsonPath("$[0].authorAnonymized", is(true)));
+
+		mockMvc.perform(get("/api/users/{userId}/public-profile", userId))
+				.andExpect(status().isNotFound());
+
+		mockMvc.perform(get("/api/me/settings")
+						.header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+				.andExpect(status().isUnauthorized());
 	}
 
 	@Test
@@ -1127,5 +1173,13 @@ class SocialControllerTest {
 				VALUES (?, ?, ?, '공유 인증', DATEADD('HOUR', -1, CURRENT_TIMESTAMP))
 				""", sessionId, roomId, userId);
 		return roomId;
+	}
+
+	private record UserWithdrawalRow(
+			String email,
+			String nickname,
+			String passwordHash,
+			String status
+	) {
 	}
 }

--- a/docs/plan/2026-05-05/withdrawal-feature-plan.md
+++ b/docs/plan/2026-05-05/withdrawal-feature-plan.md
@@ -1,0 +1,74 @@
+# 회원 탈퇴 기능 보강 계획
+
+## 목적
+- 현재 구현된 설정/소셜 영역에 회원 탈퇴 기능을 완성도 있게 보강한다.
+- README에 명시된 정책인 `POST /api/me/withdraw`, 탈퇴 계정 로그인 차단, 기존 공개 게시글 작성자 익명화를 실제 동작과 테스트로 고정한다.
+- 구현 범위는 기존 구조를 유지하며 최소 변경으로 제한한다.
+
+## 현재 확인한 상태
+- `frontend/src/pages/SettingsPage.jsx`
+  - 이미 `POST /api/me/withdraw`를 호출하고 성공 시 `logout()`을 실행한다.
+  - 확인창 문구와 탈퇴 섹션이 존재한다.
+- `backend/src/main/java/com/example/chaeklist/domain/social/controller/SocialController.java`
+  - 이미 `POST /api/me/withdraw` 엔드포인트가 존재한다.
+- `backend/src/main/java/com/example/chaeklist/domain/social/service/SocialService.java`
+  - `withdraw()`가 존재한다.
+  - 사용자의 `social_posts`를 `user_id = NULL`, `author_snapshot_nickname = '탈퇴한 사용자'`, `author_anonymized = TRUE`로 갱신한다.
+  - `users`는 `email = deleted_{id}@deleted.local`, `nickname = deleted_{id}`, `password_hash = ''`, `status = 'DELETED'`로 갱신한다.
+- `docs/mysql-ddl.sql`
+  - `users.status`는 `ACTIVE`, `INACTIVE`, `DELETED`를 허용한다.
+  - `users.email`, `users.nickname`은 unique key가 있어 탈퇴 시 대체 값이 필요하다.
+- 테스트 상태
+  - `SocialControllerTest`에는 공개/비공개/비활성 계정 노출 테스트는 있으나, `withdraw` 직접 회귀 테스트는 아직 확인되지 않았다.
+- 주의점
+  - `TokenService.validateAccessToken()`은 JWT claim만 검증하고 DB의 최신 사용자 상태를 재조회하지 않는다.
+  - 따라서 탈퇴 직후 프론트는 로그아웃되지만, 이미 발급된 access token은 만료 전까지 서버에서 `ACTIVE` claim으로 통과할 수 있다.
+
+## 구현 정책
+- 탈퇴는 soft delete로 처리한다.
+- 탈퇴한 사용자는 재로그인할 수 없어야 한다.
+- 탈퇴 직후 기존 access token으로 보호 API를 호출해도 401이 되어야 한다.
+- 기존 공개 게시글은 삭제하지 않고 작성자 정보를 익명화해 유지한다.
+- 탈퇴 사용자 공개 프로필은 조회되지 않아야 한다.
+- 탈퇴 사용자가 호스트인 모각독은 기존 공개 조회 정책처럼 `host.status = 'ACTIVE'` 조건에 의해 공개 목록에서 제외되는 현 정책을 유지한다.
+- DB 스키마 변경은 우선 필요하지 않은 것으로 본다.
+
+## 구현 단위
+1. `[Backend 탈퇴 인증 차단 보강]` -> verify: `POST /api/me/withdraw` 후 같은 access token으로 `/api/me/settings` 또는 `/api/me/mypage` 호출 시 401
+   - `TokenService.validateAccessToken()`이 토큰의 `sub`에 해당하는 사용자를 DB에서 조회하고, 현재 `users.status = 'ACTIVE'`일 때만 `AuthenticatedUser`를 반환하도록 보강한다.
+   - 토큰 claim의 status만 신뢰하지 않도록 한다.
+   - 조회 대상 사용자가 없거나 `DELETED/INACTIVE`이면 `TokenException`을 던진다.
+
+2. `[Backend 탈퇴 처리 회귀 테스트 추가]` -> verify: `cd backend && .\gradlew.bat test --tests com.example.chaeklist.SocialControllerTest`
+   - 탈퇴 API 성공 시 `204 No Content`.
+   - `users.status = 'DELETED'`, `email/nickname/password_hash`가 익명화/무효화되는지 검증한다.
+   - 기존 공개 게시글은 남고 `user_id = NULL`, `author_anonymized = TRUE`, 표시 닉네임이 `탈퇴한 사용자`인지 검증한다.
+   - 탈퇴 사용자 공개 프로필은 404 또는 공개 목록 제외로 검증한다.
+   - 탈퇴 후 같은 토큰으로 보호 API 접근이 401인지 검증한다.
+
+3. `[Frontend 탈퇴 UX 안정화]` -> verify: `cd frontend && npm run build`
+   - 현재 `window.confirm` 기반 흐름은 유지하되, 요청 중 버튼 중복 클릭을 막는 pending 상태를 추가한다.
+   - 401이면 기존 패턴대로 `logout()`한다.
+   - 실패 메시지는 현재의 일반 메시지를 유지하거나 서버 메시지가 있으면 우선 표시한다.
+   - 성공 후 사용자가 인증 상태에 남지 않도록 현재 `logout()` 흐름을 유지한다.
+
+4. `[공개 노출 정책 점검]` -> verify: `cd backend && .\gradlew.bat test`
+   - 피드/좋아요한 글/검색/공개 프로필/모각독 목록의 탈퇴 사용자 노출 정책을 기존 조건과 맞춘다.
+   - 공개 게시글은 `user_id = NULL`로 남기기 때문에 피드 조건 `(sp.user_id IS NULL OR u.status = 'ACTIVE')`를 통과하는 현재 정책을 유지한다.
+   - 작성자 배지/공개 프로필 링크처럼 `authorUserId`가 필요한 부가 정보는 `null` 처리로 유지한다.
+
+## 예상 변경 파일
+- `backend/src/main/java/com/example/chaeklist/domain/auth/util/TokenService.java`
+- `backend/src/test/java/com/example/chaeklist/SocialControllerTest.java`
+- 필요 시 `backend/src/test/java/com/example/chaeklist/AuthControllerTest.java`
+- `frontend/src/pages/SettingsPage.jsx`
+
+## DB 변경 여부
+- `docs/mysql-ddl.sql` 기준으로는 추가 컬럼이나 제약 변경이 필요하지 않다.
+- 이미 `users.status`에 `DELETED`가 있고, `email/nickname` unique 제약을 피하기 위한 익명화 값도 현재 구현에서 만들고 있다.
+- 따라서 사용자 실행 SQL은 없을 가능성이 높다.
+
+## 남은 확인 사항
+- 탈퇴 계정의 기존 알림, 좋아요, 차단, 신고 이력은 감사/무결성 목적상 유지하는 것이 현재 구조와 가장 맞다.
+- 탈퇴 사용자가 호스트였던 진행 중 모각독을 자동 취소할지 여부는 별도 정책 결정이 필요하다. 이번 계획에서는 기존 공개 목록 제외 정책만 유지한다.
+- refresh token API가 현재 README/코드에 명확히 드러나지 않아, 이번 범위는 access token 검증 강화로 제한한다.

--- a/frontend/src/pages/SettingsPage.jsx
+++ b/frontend/src/pages/SettingsPage.jsx
@@ -13,6 +13,8 @@ export default function SettingsPage() {
   const [myPosts, setMyPosts] = useState([]);
   const [likedPosts, setLikedPosts] = useState([]);
   const [message, setMessage] = useState("");
+  const [withdrawConfirmOpen, setWithdrawConfirmOpen] = useState(false);
+  const [withdrawPending, setWithdrawPending] = useState(false);
 
   useEffect(() => {
     let ignore = false;
@@ -109,18 +111,28 @@ export default function SettingsPage() {
   }
 
   async function withdraw() {
-    const confirmed = window.confirm("탈퇴하면 계정은 비활성화되고 기존 공개 게시글 작성자는 익명화됩니다.");
-    if (!confirmed) {
+    if (withdrawPending) {
       return;
     }
-    const response = await fetch("/api/me/withdraw", {
-      headers: { Authorization: `Bearer ${accessToken}` },
-      method: "POST",
-    });
-    if (response.ok) {
-      logout();
-    } else {
+    setWithdrawPending(true);
+    setMessage("");
+    try {
+      const response = await fetch("/api/me/withdraw", {
+        headers: { Authorization: `Bearer ${accessToken}` },
+        method: "POST",
+      });
+      if (response.ok || response.status === 401) {
+        logout();
+        return;
+      }
+      const data = await response.json().catch(() => ({}));
+      setMessage(data.message ?? "회원 탈퇴를 처리하지 못했습니다.");
+      setWithdrawConfirmOpen(false);
+    } catch {
       setMessage("회원 탈퇴를 처리하지 못했습니다.");
+      setWithdrawConfirmOpen(false);
+    } finally {
+      setWithdrawPending(false);
     }
   }
 
@@ -213,11 +225,49 @@ export default function SettingsPage() {
 
       <section className="mt-5 rounded-lg border border-[#FCA5A5] bg-white p-5 shadow-sm">
         <h2 className="text-xl font-bold text-[#991B1B]">회원 탈퇴</h2>
-        <p className="mt-3 text-sm leading-6 text-[#6B7280]">탈퇴 후 공개 게시글은 유지되며 작성자 정보는 익명화됩니다.</p>
-        <button className="mt-4 rounded-md bg-[#991B1B] px-4 py-2 text-sm font-semibold text-white" type="button" onClick={withdraw}>
+        <p className="mt-3 text-sm leading-6 text-[#6B7280]">
+          탈퇴하면 계정은 사용할 수 없고, 기존 공개 게시글은 유지되며 작성자 정보는 익명화됩니다.
+        </p>
+        <button
+          className="mt-4 rounded-md bg-[#991B1B] px-4 py-2 text-sm font-semibold text-white disabled:cursor-not-allowed disabled:bg-[#FCA5A5]"
+          type="button"
+          disabled={withdrawPending}
+          onClick={() => setWithdrawConfirmOpen(true)}
+        >
           회원 탈퇴
         </button>
       </section>
+
+      {withdrawConfirmOpen ? (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 px-5">
+          <div className="w-full max-w-md rounded-lg border border-[#FCA5A5] bg-white p-5 shadow-xl">
+            <p className="text-sm font-semibold text-[#991B1B]">회원 탈퇴 확인</p>
+            <h2 className="mt-2 text-xl font-bold text-[#1E2A38]">정말 탈퇴하시겠습니까?</h2>
+            <div className="mt-4 space-y-2 text-sm leading-6 text-[#6B7280]">
+              <p>탈퇴 즉시 이 계정으로 다시 로그인할 수 없습니다.</p>
+              <p>기존 공개 게시글은 삭제되지 않고 작성자가 탈퇴한 사용자로 표시됩니다.</p>
+            </div>
+            <div className="mt-5 flex flex-col gap-2 sm:flex-row sm:justify-end">
+              <button
+                className="rounded-md border border-[#E5E7EB] px-4 py-2 text-sm font-semibold text-[#1E2A38] disabled:cursor-not-allowed disabled:text-[#9CA3AF]"
+                type="button"
+                disabled={withdrawPending}
+                onClick={() => setWithdrawConfirmOpen(false)}
+              >
+                취소
+              </button>
+              <button
+                className="rounded-md bg-[#991B1B] px-4 py-2 text-sm font-semibold text-white disabled:cursor-not-allowed disabled:bg-[#FCA5A5]"
+                type="button"
+                disabled={withdrawPending}
+                onClick={withdraw}
+              >
+                {withdrawPending ? "처리 중" : "탈퇴하기"}
+              </button>
+            </div>
+          </div>
+        </div>
+      ) : null}
     </section>
   );
 }


### PR DESCRIPTION
## 📌 개요
> 어떤 변경 사항인지

- 회원 탈퇴 기능 보강
- 탈퇴 후 기존 access token 차단
- 설정 화면 회원 탈퇴 확인 UI 및 API 연동 개선

---

## 🔗 관련 이슈
- Closes #48 

---

## ✨ 작업 내용
> 주요 변경 사항

### 🔹 Backend
- 탈퇴 API 회귀 테스트 추가
- 탈퇴 시 사용자 계정 `DELETED` 처리 검증
- 탈퇴 시 이메일/닉네임/비밀번호 익명화 및 무효화 검증
- 기존 공개 게시글 작성자 익명화 검증
- 탈퇴 후 기존 access token으로 보호 API 접근 시 401 처리되도록 인증 검증 보강

### 🔹 Frontend
- 설정 페이지 회원 탈퇴 확인 모달 구현
- `POST /api/me/withdraw` API 연동 개선
- 탈퇴 요청 중 중복 클릭 방지
- 탈퇴 성공 또는 401 응답 시 로그아웃 처리
- 탈퇴 실패 시 서버 메시지 또는 기본 실패 메시지 표시

---

## 🧪 테스트 결과
- [x] 로컬 테스트 완료
- [x] API 정상 동작 확인
- [x] 에러 케이스 확인

---

## 📸 스크린샷 (선택)
> UI 변경 시 첨부

- 설정 페이지 회원 탈퇴 확인 모달 추가

---

## ⚠️ 주의사항
- 탈퇴 후 기존 공개 게시글은 삭제하지 않고 작성자 정보만 익명화됨
- 탈퇴 사용자는 기존 access token으로도 보호 API 접근 불가
- 실제 탈퇴 테스트 시 계정 복구가 어려우므로 테스트 계정 사용 필요
- DB 스키마 변경 없음

---

## 🚀 배포 전 체크리스트
- [x] 빌드 성공 (`npm run build`)
- [x] 백엔드 테스트 성공 (`./gradlew.bat test`)
- [ ] 환경변수 설정 확인
- [x] DB 영향 여부 확인

---

## 💬 리뷰 포인트
> 리뷰어가 집중해서 봐야 할 부분

- `TokenService`에서 토큰 claim이 아닌 DB의 현재 사용자 상태를 기준으로 인증하는 방식
- 탈퇴 후 기존 access token 차단 처리
- 공개 게시글 익명화 정책이 feed/profile/search 정책과 충돌하지 않는지
- 설정 페이지 탈퇴 모달의 API 실패/성공 처리 흐름
